### PR TITLE
TOOL-1053 #comment Fix the URL parsing logic for the long SSH protocol version.

### DIFF
--- a/git.go
+++ b/git.go
@@ -136,7 +136,7 @@ func isFork(repoURL, prRepoURL string) bool {
 // git@hostname:owner/repository.git
 // ssh://git@hostname:port/owner/repository.git
 func getRepo(url string) string {
-	var host, repo string
+	var host, repo, port string
 	switch {
 	case strings.HasPrefix(url, "https://"):
 		url = strings.TrimPrefix(url, "https://")
@@ -148,8 +148,17 @@ func getRepo(url string) string {
 		host, repo = url[:idx], url[idx+1:]
 	case strings.HasPrefix(url, "ssh://"):
 		url = url[strings.Index(url, "@")+1:]
-		host = url[:strings.Index(url, ":")]
-		repo = url[strings.Index(url, "/")+1:]
+		if strings.Contains(url, ":") {
+			idxColon, idxSlash := strings.Index(url, ":"), strings.Index(url, "/")
+			host, port, repo = url[:idxColon], url[idxColon+1:idxSlash], url[idxSlash+1:]
+		} else {
+			idx := strings.Index(url, "/")
+			host, repo = url[:idx], url[idx+1:]
+		}
+	}
+
+	if port != "" {
+		return host + ":" + port + "/" + strings.TrimSuffix(repo, ".git")
 	}
 	return host + "/" + strings.TrimSuffix(repo, ".git")
 }

--- a/git.go
+++ b/git.go
@@ -156,10 +156,6 @@ func getRepo(url string) string {
 			host, repo = url[:idx], url[idx+1:]
 		}
 	}
-
-	if port != "" {
-		return host + ":" + port + "/" + strings.TrimSuffix(repo, ".git")
-	}
 	return host + "/" + strings.TrimSuffix(repo, ".git")
 }
 

--- a/git.go
+++ b/git.go
@@ -136,7 +136,7 @@ func isFork(repoURL, prRepoURL string) bool {
 // git@hostname:owner/repository.git
 // ssh://git@hostname:port/owner/repository.git
 func getRepo(url string) string {
-	var host, repo, port string
+	var host, repo string
 	switch {
 	case strings.HasPrefix(url, "https://"):
 		url = strings.TrimPrefix(url, "https://")
@@ -150,7 +150,7 @@ func getRepo(url string) string {
 		url = url[strings.Index(url, "@")+1:]
 		if strings.Contains(url, ":") {
 			idxColon, idxSlash := strings.Index(url, ":"), strings.Index(url, "/")
-			host, port, repo = url[:idxColon], url[idxColon+1:idxSlash], url[idxSlash+1:]
+			host, repo = url[:idxColon], url[idxSlash+1:]
 		} else {
 			idx := strings.Index(url, "/")
 			host, repo = url[:idx], url[idx+1:]

--- a/git_test.go
+++ b/git_test.go
@@ -1,6 +1,8 @@
 package main
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestFetchArg(t *testing.T) {
 	for input, expected := range map[string]string{
@@ -14,16 +16,38 @@ func TestFetchArg(t *testing.T) {
 	}
 }
 
-func TestGetRepo(t *testing.T) {
-	expected := "github.com/bitrise-samples/git-clone-test"
-	for _, input := range []string{
-		"https://github.com/bitrise-samples/git-clone-test.git",
-		"git@github.com:bitrise-samples/git-clone-test.git",
-		"ssh://git@github.com:22/bitrise-samples/git-clone-test.git",
-	} {
-		actual := getRepo(input)
-		if actual != expected {
-			t.Errorf("getRepo(%q), expected %q, actual %q", input, expected, actual)
-		}
+func Test_getRepo(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "HTTPS URL",
+			url:  "https://github.com/bitrise-samples/git-clone-test.git",
+			want: "github.com/bitrise-samples/git-clone-test",
+		},
+		{
+			name: "Long SSH URL",
+			url:  "ssh://git@github.com/bitrise-samples/git-clone-test.git",
+			want: "github.com/bitrise-samples/git-clone-test",
+		},
+		{
+			name: "Long SSH URL with a specific port",
+			url:  "ssh://git@github.com:22/bitrise-samples/git-clone-test.git",
+			want: "github.com:22/bitrise-samples/git-clone-test",
+		},
+		{
+			name: "Short SSH URL",
+			url:  "git@github.com:bitrise-samples/git-clone-test.git",
+			want: "github.com/bitrise-samples/git-clone-test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getRepo(tt.url); got != tt.want {
+				t.Errorf("getRepo() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- If the porst is not specified for the long version `ssh://git@hostname:port/owner/repository.git` of the SSH URL, the git URL parser fails.