### PR TITLE
Force fetching `refs/heads` when fetching branch

### DIFF
--- a/git.go
+++ b/git.go
@@ -274,7 +274,7 @@ func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool) error {
 			if isTag {
 				opts = append(opts, "origin", branch)
 			} else {
-				opts = append(opts, "origin", "refs/heads/", branch)
+				opts = append(opts, "origin", "refs/heads/" + branch)
 			}
 		}
 		return gitCmd.Fetch(opts...)

--- a/git.go
+++ b/git.go
@@ -271,7 +271,11 @@ func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool) error {
 			opts = append(opts, "--tags")
 		}
 		if branch == arg {
-			opts = append(opts, "origin", branch)
+			if isTag {
+				opts = append(opts, "origin", branch)
+			} else {
+				opts = append(opts, "origin", "refs/heads/", branch)
+			}
 		}
 		return gitCmd.Fetch(opts...)
 	}); err != nil {


### PR DESCRIPTION
According to Git's refspec resolution order tags have precedence:
https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-emltrefnamegtemegemmasterememheadsmasterememrefsheadsmasteremu

In a situation when repository holds tag and a branch of the same name
issuing a build from bitrise specifying name of the branch will produce
command

```
git fetch origin <branchname>
```

and because of how git works it will only pull tag object without
putting tag reference into `.git/refs/tags` because it does not specify
`--tags` explicitly (assuming this is a branch)

and the latter command

```
git checkout <branchname>
```

will fail since both `.git/refs/tags` and `.git/refs/heads` are empty

Failsafe way of fetching branch in this situation would be:

```
get fetch origin refs/heads/<branchname>
```

and this operation will create proper ref in `.git/refs/heads` and the
following

```
git checkout <branchname>
```

will succeed.