### PR TITLE
Add option to disable Auto Merge + Add option to not check out tags + Add option to apply fetch settings to branches

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -40,6 +40,7 @@ workflows:
     - _test_commit_logs
     - _test_hosted_git_notfork
     - _test_unrelated_histories
+    - _test_unrelated_histories_with_options
     - _test_hosted_git_ssh_prefix
     steps:
     - activate-ssh-key:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -513,6 +513,42 @@ workflows:
         inputs:
         - dir_to_check: $CLONE_INTO_DIR
 
+  _test_unrelated_histories_with_options:
+    before_run:
+    - _create_tmpdir
+    steps:
+    - path::./:
+        run_if: true
+        inputs:
+        - clone_into_dir: $CLONE_INTO_DIR
+        - pull_request_id: 8
+        - pull_request_merge_branch: "pull/8/merge"
+        - pull_request_repository_url: $GIT_REPOSITORY_URL
+        - branch_dest: "unrelated-histories/master"
+        - commit: "62af44590c7a2b937726f2c3024a88a129b330b5"
+        - tag: ""
+        - branch: ""
+        - clone_depth: "50"
+        - manual_merge: "no"
+        - checkout_merged_state: "no"
+        - options_on_branches: "yes"
+        - fetch_tags: "no"
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "GIT_CLONE_COMMIT_HASH: ${GIT_CLONE_COMMIT_HASH}"
+            echo "GIT_CLONE_COMMIT_MESSAGE_SUBJECT: ${GIT_CLONE_COMMIT_MESSAGE_SUBJECT}"
+            echo "GIT_CLONE_COMMIT_MESSAGE_BODY: ${GIT_CLONE_COMMIT_MESSAGE_BODY}"
+            echo "GIT_CLONE_COMMIT_COUNT: ${GIT_CLONE_COMMIT_COUNT}"
+            echo "GIT_CLONE_COMMIT_AUTHOR_NAME: ${GIT_CLONE_COMMIT_AUTHOR_NAME}"
+            echo "GIT_CLONE_COMMIT_AUTHOR_EMAIL: ${GIT_CLONE_COMMIT_AUTHOR_EMAIL}"
+            echo "GIT_CLONE_COMMIT_COMMITER_NAME: ${GIT_CLONE_COMMIT_COMMITER_NAME}"
+            echo "GIT_CLONE_COMMIT_COMMITER_EMAIL: ${GIT_CLONE_COMMIT_COMMITER_EMAIL}"
+    - ensure-clean-git:
+        inputs:
+        - dir_to_check: $CLONE_INTO_DIR
+
   _test_too_long_commit_message:
     before_run:
       - _create_tmpdir

--- a/git.go
+++ b/git.go
@@ -196,6 +196,7 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 		if err := pull(gitCmd, branchDest); err != nil {
 			return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)
 		}
+		log.Printf("AAA gitCmd.Merge")
 		if err := run(gitCmd.Merge(mergeArg(mergeBranch))); err != nil {
 			if depth == 0 {
 				return fmt.Errorf("merge %q: %v", mergeArg(mergeBranch), err)
@@ -209,6 +210,7 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 			}); err != nil {
 				return fmt.Errorf("fetch failed, error: %v", err)
 			}
+			log.Printf("BBB gitCmd.Merge")
 			if err := run(gitCmd.Merge(mergeArg(mergeBranch))); err != nil {
 				return fmt.Errorf("merge %q: %v", mergeArg(mergeBranch), err)
 			}
@@ -253,6 +255,8 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 		if err := run(gitCmd.Fetch("origin", branch)); err != nil {
 			return fmt.Errorf("fetch failed, error: %v", err)
 		}
+		
+		log.Printf("CCC gitCmd.Merge")
 		if err := run(gitCmd.Merge(commit)); err != nil {
 			return fmt.Errorf("merge failed (%s), error: %v", commit, err)
 		}
@@ -301,5 +305,6 @@ func pull(gitCmd git.Git, branchDest string) error {
 	if err := run(gitCmd.Checkout(branchDest)); err != nil {
 		return fmt.Errorf("checkout failed (%s), error: %v", branchDest, err)
 	}
+	log.Printf("DDD gitCmd.Merge")
 	return run(gitCmd.Merge("origin/" + branchDest))
 }

--- a/git.go
+++ b/git.go
@@ -226,16 +226,18 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 	return nil
 }
 
-func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool, depth int, isTag bool, fetchTags bool) error {
+func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool, depth int, isTag bool, fetchTags bool, optionsOnBranches bool) error {
 	var opts []string
-	if !fetchTags {
-		opts = append(opts, "--no-tags")
-	}
-	if depth != 0 {
-		opts = append(opts, "--depth="+strconv.Itoa(depth))
-	}
-	if isTag {
-		opts = append(opts, "--tags")
+	if optionsOnBranches {
+		if !fetchTags {
+			opts = append(opts, "--no-tags")
+		}
+		if depth != 0 {
+			opts = append(opts, "--depth="+strconv.Itoa(depth))
+		}
+		if isTag {
+			opts = append(opts, "--tags")
+		}
 	}
 	if branchDest != "" {
 		opts = append(opts, "origin", branchDest)
@@ -269,7 +271,11 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 			return fmt.Errorf("merge failed (fork/%s), error: %v", branch, err)
 		}
 	} else {
-		opts = opts[:len(opts) - 2]
+		if optionsOnBranches {
+			opts = opts[:len(opts) - 2]
+		} else {
+			opts = [:0]
+		}
 		if branch != "" {
 			opts = append(opts, "origin", branch)
 		}
@@ -284,7 +290,7 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 	return nil
 }
 
-func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool, fetchTags bool) error {
+func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool, fetchTags bool, optionsOnBranches bool) error {
 	if err := runWithRetry(func() *command.Model {
 		var opts []string
 		if !fetchTags {

--- a/git.go
+++ b/git.go
@@ -226,7 +226,7 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 	return nil
 }
 
-func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool, depth int, isTag bool) error {
+func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool, depth int, isTag bool, fetchTags bool) error {
 	var opts []string
 	if depth != 0 {
 		opts = append(opts, "--depth="+strconv.Itoa(depth))
@@ -236,6 +236,9 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 	}
 	if branch != "" {
 		opts = append(opts, "origin", branchDest)
+	}
+	if fetchTags {
+		opts = append(opts, "--no-tags")
 	}
 	if err := runWithRetry(func() *command.Model { return gitCmd.Fetch(opts...) }); err != nil {
 		return fmt.Errorf("fetch failed, error: %v", err)
@@ -277,7 +280,7 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 	return nil
 }
 
-func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool) error {
+func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool, fetchTags bool) error {
 	if err := runWithRetry(func() *command.Model {
 		var opts []string
 		if depth != 0 {
@@ -288,6 +291,9 @@ func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool) error {
 		}
 		if branch != "" {
 			opts = append(opts, "origin", branch)
+		}
+		if fetchTags {
+			opts = append(opts, "--no-tags")
 		}
 		return gitCmd.Fetch(opts...)
 	}); err != nil {

--- a/git.go
+++ b/git.go
@@ -238,13 +238,19 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 	return nil
 }
 
-func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string) error {
+func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool) error {
 	if err := runWithRetry(func() *command.Model { return gitCmd.Fetch("origin", branchDest) }); err != nil {
 		return fmt.Errorf("fetch failed, error: %v", err)
 	}
 	log.Printf("EEE pull")
-	if err := pull(gitCmd, branchDest); err != nil {
-		return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)
+	if autoMerge {
+		if err := pull(gitCmd, branchDest); err != nil {
+			return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)
+		}
+	} else {
+		if err := run(gitCmd.Checkout(branchDest)); err != nil {
+			return fmt.Errorf("checkout failed (%s), error: %v", branchDest, err)
+		}
 	}
 	commitHash, err := output(gitCmd.Log("%H"))
 	if err != nil {

--- a/git.go
+++ b/git.go
@@ -190,20 +190,17 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 
 	if mergeBranch != "" {
 		log.Printf("==> mergeBranch 1")
-		if err := run(gitCmd.Checkout(branchDest)); err != nil {
-			return fmt.Errorf("checkout failed (%s), error: %v", branchDest, err)
-		}
-		
-		log.Printf("==> mergeBranch 1.1")
 		if err := runWithRetry(func() *command.Model {
 			return gitCmd.Fetch("origin", fetchArg(mergeBranch))
 		}); err != nil {
 			return fmt.Errorf("fetch Pull Request branch failed (%s), error: %v",
 				mergeBranch, err)
 		}
-		//if err := pull(gitCmd, branchDest); err != nil {
-		//	return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)
-		//}
+		
+		log.Printf("==> mergeBranch 1.1")
+		if err := pull(gitCmd, branchDest); err != nil {
+			return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)
+		}
 		log.Printf("==> mergeBranch 1.2")
 		if err := run(gitCmd.Merge(mergeArg(mergeBranch))); err != nil {
 			log.Printf("==> mergeBranch 1.2.1")

--- a/git.go
+++ b/git.go
@@ -226,7 +226,7 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 	return nil
 }
 
-func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool, isTag bool, depth int) error {
+func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool, depth int, isTag bool) error {
 	var opts []string
 	if depth != 0 {
 		opts = append(opts, "--depth="+strconv.Itoa(depth))

--- a/git.go
+++ b/git.go
@@ -257,6 +257,7 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 			return fmt.Errorf("merge failed (fork/%s), error: %v", branch, err)
 		}
 	} else {
+		log.Printf("XXXX")
 		if err := run(gitCmd.Fetch("origin", branch)); err != nil {
 			return fmt.Errorf("fetch failed, error: %v", err)
 		}

--- a/git.go
+++ b/git.go
@@ -190,15 +190,16 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 
 	if mergeBranch != "" {
 		log.Printf("==> mergeBranch 1")
+		if err := run(gitCmd.Checkout(branchDest)); err != nil {
+			return fmt.Errorf("checkout failed (%s), error: %v", branchDest, err)
+		}
+		
+		log.Printf("==> mergeBranch 1.1")
 		if err := runWithRetry(func() *command.Model {
 			return gitCmd.Fetch("origin", fetchArg(mergeBranch))
 		}); err != nil {
 			return fmt.Errorf("fetch Pull Request branch failed (%s), error: %v",
 				mergeBranch, err)
-		}
-		log.Printf("==> mergeBranch 1.1")
-		if err := run(gitCmd.Checkout(branchDest)); err != nil {
-			return fmt.Errorf("checkout failed (%s), error: %v", branchDest, err)
 		}
 		//if err := pull(gitCmd, branchDest); err != nil {
 		//	return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)

--- a/git.go
+++ b/git.go
@@ -226,8 +226,18 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 	return nil
 }
 
-func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool) error {
-	if err := runWithRetry(func() *command.Model { return gitCmd.Fetch("origin", branchDest) }); err != nil {
+func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool, isTag bool, depth int) error {
+	var opts []string
+	if depth != 0 {
+		opts = append(opts, "--depth="+strconv.Itoa(depth))
+	}
+	if isTag {
+		opts = append(opts, "--tags")
+	}
+	if branch != "" {
+		opts = append(opts, "origin", branchDest)
+	}
+	if err := runWithRetry(func() *command.Model { return gitCmd.Fetch(opts...) }); err != nil {
 		return fmt.Errorf("fetch failed, error: %v", err)
 	}
 	if autoMerge {

--- a/git.go
+++ b/git.go
@@ -237,7 +237,7 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 	if isTag {
 		opts = append(opts, "--tags")
 	}
-	if branch != "" {
+	if branchDest != "" {
 		opts = append(opts, "origin", branchDest)
 	}
 	if err := runWithRetry(func() *command.Model { return gitCmd.Fetch(opts...) }); err != nil {
@@ -269,16 +269,7 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 			return fmt.Errorf("merge failed (fork/%s), error: %v", branch, err)
 		}
 	} else {
-		opts = []
-		if !fetchTags {
-			opts = append(opts, "--no-tags")
-		}
-		if depth != 0 {
-			opts = append(opts, "--depth="+strconv.Itoa(depth))
-		}
-		if isTag {
-			opts = append(opts, "--tags")
-		}
+		opts = opts[:len(opts) - 1]
 		if branch != "" {
 			opts = append(opts, "origin", branch)
 		}

--- a/git.go
+++ b/git.go
@@ -228,14 +228,16 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 
 func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool, depth int, isTag bool, fetchTags bool, optionsOnBranches bool) error {
 	var opts []string
-	if !fetchTags {
-		opts = append(opts, "--no-tags")
-	}
-	if depth != 0 {
-		opts = append(opts, "--depth="+strconv.Itoa(depth))
-	}
-	if isTag {
-		opts = append(opts, "--tags")
+	if optionsOnBranches {
+		if !fetchTags {
+			opts = append(opts, "--no-tags")
+		}
+		if depth != 0 {
+			opts = append(opts, "--depth="+strconv.Itoa(depth))
+		}
+		if isTag {
+			opts = append(opts, "--tags")
+		}
 	}
 	if branchDest != "" {
 		opts = append(opts, "origin", branchDest)

--- a/git.go
+++ b/git.go
@@ -228,6 +228,9 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 
 func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool, depth int, isTag bool, fetchTags bool) error {
 	var opts []string
+	if !fetchTags {
+		opts = append(opts, "--no-tags")
+	}
 	if depth != 0 {
 		opts = append(opts, "--depth="+strconv.Itoa(depth))
 	}
@@ -236,9 +239,6 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 	}
 	if branch != "" {
 		opts = append(opts, "origin", branchDest)
-	}
-	if !fetchTags {
-		opts = append(opts, "--no-tags")
 	}
 	if err := runWithRetry(func() *command.Model { return gitCmd.Fetch(opts...) }); err != nil {
 		return fmt.Errorf("fetch failed, error: %v", err)
@@ -283,6 +283,9 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool, fetchTags bool) error {
 	if err := runWithRetry(func() *command.Model {
 		var opts []string
+		if !fetchTags {
+			opts = append(opts, "--no-tags")
+		}
 		if depth != 0 {
 			opts = append(opts, "--depth="+strconv.Itoa(depth))
 		}
@@ -291,9 +294,6 @@ func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool, fetchTa
 		}
 		if branch != "" {
 			opts = append(opts, "origin", branch)
-		}
-		if !fetchTags {
-			opts = append(opts, "--no-tags")
 		}
 		return gitCmd.Fetch(opts...)
 	}); err != nil {

--- a/git.go
+++ b/git.go
@@ -269,7 +269,20 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 			return fmt.Errorf("merge failed (fork/%s), error: %v", branch, err)
 		}
 	} else {
-		if err := run(gitCmd.Fetch("origin", branch)); err != nil {
+		opts = []
+		if !fetchTags {
+			opts = append(opts, "--no-tags")
+		}
+		if depth != 0 {
+			opts = append(opts, "--depth="+strconv.Itoa(depth))
+		}
+		if isTag {
+			opts = append(opts, "--tags")
+		}
+		if branch != "" {
+			opts = append(opts, "origin", branch)
+		}
+		if err := run(gitCmd.Fetch(opts...)); err != nil {
 			return fmt.Errorf("fetch failed, error: %v", err)
 		}
 		if err := run(gitCmd.Merge(commit)); err != nil {

--- a/git.go
+++ b/git.go
@@ -193,9 +193,13 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 			return fmt.Errorf("fetch Pull Request branch failed (%s), error: %v",
 				mergeBranch, err)
 		}
-		if err := pull(gitCmd, branchDest); err != nil {
-			return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)
+		log.Printf("AAA pull -> checkout")
+		if err := run(gitCmd.Checkout(branchDest)); err != nil {
+			return fmt.Errorf("checkout failed (%s), error: %v", branchDest, err)
 		}
+		//if err := pull(gitCmd, branchDest); err != nil {
+		//	return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)
+		//}
 		log.Printf("AAA gitCmd.Merge")
 		if err := run(gitCmd.Merge(mergeArg(mergeBranch))); err != nil {
 			if depth == 0 {

--- a/git.go
+++ b/git.go
@@ -228,16 +228,14 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 
 func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool, depth int, isTag bool, fetchTags bool, optionsOnBranches bool) error {
 	var opts []string
-	if optionsOnBranches {
-		if !fetchTags {
-			opts = append(opts, "--no-tags")
-		}
-		if depth != 0 {
-			opts = append(opts, "--depth="+strconv.Itoa(depth))
-		}
-		if isTag {
-			opts = append(opts, "--tags")
-		}
+	if !fetchTags {
+		opts = append(opts, "--no-tags")
+	}
+	if depth != 0 {
+		opts = append(opts, "--depth="+strconv.Itoa(depth))
+	}
+	if isTag {
+		opts = append(opts, "--tags")
 	}
 	if branchDest != "" {
 		opts = append(opts, "origin", branchDest)

--- a/git.go
+++ b/git.go
@@ -274,7 +274,7 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 		if optionsOnBranches {
 			opts = opts[:len(opts) - 2]
 		} else {
-			opts = [:0]
+			opts = opts[:0]
 		}
 		if branch != "" {
 			opts = append(opts, "origin", branch)

--- a/git.go
+++ b/git.go
@@ -271,10 +271,17 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 			return fmt.Errorf("merge failed (fork/%s), error: %v", branch, err)
 		}
 	} else {
+		opts = opts[:0]
 		if optionsOnBranches {
-			opts = opts[:len(opts) - 2]
-		} else {
-			opts = opts[:0]
+			if !fetchTags {
+				opts = append(opts, "--no-tags")
+			}
+			if depth != 0 {
+				opts = append(opts, "--depth="+strconv.Itoa(depth))
+			}
+			if isTag {
+				opts = append(opts, "--tags")
+			}
 		}
 		if branch != "" {
 			opts = append(opts, "origin", "refs/heads/"+branch)

--- a/git.go
+++ b/git.go
@@ -257,7 +257,6 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 			return fmt.Errorf("merge failed (fork/%s), error: %v", branch, err)
 		}
 	} else {
-		log.Printf("XXXX")
 		if err := run(gitCmd.Fetch("origin", branch)); err != nil {
 			return fmt.Errorf("fetch failed, error: %v", err)
 		}

--- a/git.go
+++ b/git.go
@@ -237,7 +237,7 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 	if branch != "" {
 		opts = append(opts, "origin", branchDest)
 	}
-	if fetchTags {
+	if !fetchTags {
 		opts = append(opts, "--no-tags")
 	}
 	if err := runWithRetry(func() *command.Model { return gitCmd.Fetch(opts...) }); err != nil {
@@ -292,7 +292,7 @@ func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool, fetchTa
 		if branch != "" {
 			opts = append(opts, "origin", branch)
 		}
-		if fetchTags {
+		if !fetchTags {
 			opts = append(opts, "--no-tags")
 		}
 		return gitCmd.Fetch(opts...)

--- a/git.go
+++ b/git.go
@@ -193,7 +193,6 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 			return fmt.Errorf("fetch Pull Request branch failed (%s), error: %v",
 				mergeBranch, err)
 		}
-		
 		if err := pull(gitCmd, branchDest); err != nil {
 			return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)
 		}
@@ -260,7 +259,6 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 		if err := run(gitCmd.Fetch("origin", branch)); err != nil {
 			return fmt.Errorf("fetch failed, error: %v", err)
 		}
-		
 		if err := run(gitCmd.Merge(commit)); err != nil {
 			return fmt.Errorf("merge failed (%s), error: %v", commit, err)
 		}

--- a/git.go
+++ b/git.go
@@ -232,6 +232,7 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 	if err := runWithRetry(func() *command.Model { return gitCmd.Fetch("origin", branchDest) }); err != nil {
 		return fmt.Errorf("fetch failed, error: %v", err)
 	}
+	log.Printf("EEE pull")
 	if err := pull(gitCmd, branchDest); err != nil {
 		return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)
 	}

--- a/git.go
+++ b/git.go
@@ -290,7 +290,7 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 	return nil
 }
 
-func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool, fetchTags bool, optionsOnBranches bool) error {
+func checkout(gitCmd git.Git, arg, branch string, depth int, isTag bool, fetchTags bool) error {
 	if err := runWithRetry(func() *command.Model {
 		var opts []string
 		if !fetchTags {

--- a/git.go
+++ b/git.go
@@ -269,7 +269,7 @@ func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest 
 			return fmt.Errorf("merge failed (fork/%s), error: %v", branch, err)
 		}
 	} else {
-		opts = opts[:len(opts) - 1]
+		opts = opts[:len(opts) - 2]
 		if branch != "" {
 			opts = append(opts, "origin", branch)
 		}

--- a/main.go
+++ b/main.go
@@ -110,13 +110,13 @@ func mainE() error {
 
 	isPR := cfg.PRRepositoryURL != "" || cfg.PRMergeBranch != "" || cfg.PRID != 0
 	if isPR {
-		if !cfg.ManualMerge || isPrivate(cfg.PRRepositoryURL) && isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) && cfg.AutoMerge {
+		if !cfg.ManualMerge || isPrivate(cfg.PRRepositoryURL) && isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
 			log.Printf("YYY autoMerge")
 			if err := autoMerge(gitCmd, cfg.PRMergeBranch, cfg.BranchDest, cfg.BuildURL,
 				cfg.BuildAPIToken, cfg.CloneDepth, cfg.PRID); err != nil {
 				return fmt.Errorf("auto merge, error: %v", err)
 			}
-		} else {
+		} else if cfg.AutoMerge {
 			log.Printf("YYY manualMerge")
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
 				cfg.Commit, cfg.BranchDest); err != nil {

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func mainE() error {
 			}
 		} else {
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
-				cfg.Commit, cfg.BranchDest, cfg.AutoMerge); err != nil {
+				cfg.Commit, cfg.BranchDest, cfg.AutoMerge, cfg.CloneDepth, cfg.Tag != ""); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -122,7 +122,6 @@ func mainE() error {
 			}
 		}
 	} else if checkoutArg != "" {
-		
 		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != ""); err != nil {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}

--- a/main.go
+++ b/main.go
@@ -110,11 +110,13 @@ func mainE() error {
 	isPR := cfg.PRRepositoryURL != "" || cfg.PRMergeBranch != "" || cfg.PRID != 0
 	if isPR {
 		if !cfg.ManualMerge || isPrivate(cfg.PRRepositoryURL) && isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
+			log.Printf("XXX gitCmd.Merge")
 			if err := autoMerge(gitCmd, cfg.PRMergeBranch, cfg.BranchDest, cfg.BuildURL,
 				cfg.BuildAPIToken, cfg.CloneDepth, cfg.PRID); err != nil {
 				return fmt.Errorf("auto merge, error: %v", err)
 			}
 		} else {
+			log.Printf("YYY gitCmd.Merge")
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
 				cfg.Commit, cfg.BranchDest); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
@@ -126,6 +128,7 @@ func mainE() error {
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.
 		if checkoutArg == cfg.Branch {
+			log.Printf("ZZZ gitCmd.Merge")
 			if err := run(gitCmd.Merge("origin/" + cfg.Branch)); err != nil {
 				return fmt.Errorf("merge %q: %v", cfg.Branch, err)
 			}

--- a/main.go
+++ b/main.go
@@ -111,13 +111,11 @@ func mainE() error {
 	isPR := cfg.PRRepositoryURL != "" || cfg.PRMergeBranch != "" || cfg.PRID != 0
 	if isPR {
 		if !cfg.ManualMerge || isPrivate(cfg.PRRepositoryURL) && isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
-			log.Printf("YYY autoMerge")
 			if err := autoMerge(gitCmd, cfg.PRMergeBranch, cfg.BranchDest, cfg.BuildURL,
 				cfg.BuildAPIToken, cfg.CloneDepth, cfg.PRID); err != nil {
 				return fmt.Errorf("auto merge, error: %v", err)
 			}
 		} else {
-			log.Printf("YYY manualMerge")
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
 				cfg.Commit, cfg.BranchDest, cfg.AutoMerge); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
@@ -125,13 +123,11 @@ func mainE() error {
 		}
 	} else if checkoutArg != "" {
 		
-		log.Printf("ZZZ checkout")
 		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != ""); err != nil {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.
 		if checkoutArg == cfg.Branch {
-			log.Printf("ZZZ gitCmd.Merge")
 			if err := run(gitCmd.Merge("origin/" + cfg.Branch)); err != nil {
 				return fmt.Errorf("merge %q: %v", cfg.Branch, err)
 			}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type config struct {
 	ManualMerge      bool   `env:"manual_merge,opt[yes,no]"`
 	AutoMerge        bool   `env:"auto_merge,opt[yes,no]"`
 	FetchTags        bool   `env:"fetch_tags,opt[yes,no]"`
+	OptionsOnBranches bool 	`env:"options_on_branches,opt[yes,no]"`
 }
 
 const (
@@ -118,12 +119,12 @@ func mainE() error {
 			}
 		} else {
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
-				cfg.Commit, cfg.BranchDest, cfg.AutoMerge, cfg.CloneDepth, cfg.Tag != "", cfg.FetchTags); err != nil {
+				cfg.Commit, cfg.BranchDest, cfg.AutoMerge, cfg.CloneDepth, cfg.Tag != "", cfg.FetchTags, cfg.OptionsOnBranches); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
 			}
 		}
 	} else if checkoutArg != "" {
-		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != "", cfg.FetchTags); err != nil {
+		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != "", cfg.FetchTags, cfg.OptionsOnBranches); err != nil {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.

--- a/main.go
+++ b/main.go
@@ -118,12 +118,12 @@ func mainE() error {
 			}
 		} else {
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
-				cfg.Commit, cfg.BranchDest, cfg.AutoMerge, cfg.CloneDepth, cfg.Tag != "", fetch_tags); err != nil {
+				cfg.Commit, cfg.BranchDest, cfg.AutoMerge, cfg.CloneDepth, cfg.Tag != "", FetchTags); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
 			}
 		}
 	} else if checkoutArg != "" {
-		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != "", fetch_tags); err != nil {
+		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != "", FetchTags); err != nil {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func mainE() error {
 
 	isPR := cfg.PRRepositoryURL != "" || cfg.PRMergeBranch != "" || cfg.PRID != 0
 	if isPR {
-		if (!cfg.ManualMerge && cfg.AutoMerge) || isPrivate(cfg.PRRepositoryURL) && isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
+		if !cfg.ManualMerge || isPrivate(cfg.PRRepositoryURL) && isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) && cfg.AutoMerge {
 			log.Printf("YYY autoMerge")
 			if err := autoMerge(gitCmd, cfg.PRMergeBranch, cfg.BranchDest, cfg.BuildURL,
 				cfg.BuildAPIToken, cfg.CloneDepth, cfg.PRID); err != nil {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type config struct {
 	BuildAPIToken    string `env:"build_api_token"`
 	UpdateSubmodules bool   `env:"update_submodules,opt[yes,no]"`
 	ManualMerge      bool   `env:"manual_merge,opt[yes,no]"`
+	AutoMerge        bool   `env:"auto_merge,opt[yes,no]"`
 }
 
 const (
@@ -109,7 +110,7 @@ func mainE() error {
 
 	isPR := cfg.PRRepositoryURL != "" || cfg.PRMergeBranch != "" || cfg.PRID != 0
 	if isPR {
-		if !cfg.ManualMerge || isPrivate(cfg.PRRepositoryURL) && isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
+		if (!cfg.ManualMerge && cfg.AutoMerge) || isPrivate(cfg.PRRepositoryURL) && isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
 			log.Printf("YYY autoMerge")
 			if err := autoMerge(gitCmd, cfg.PRMergeBranch, cfg.BranchDest, cfg.BuildURL,
 				cfg.BuildAPIToken, cfg.CloneDepth, cfg.PRID); err != nil {

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ type config struct {
 	BuildAPIToken    string `env:"build_api_token"`
 	UpdateSubmodules bool   `env:"update_submodules,opt[yes,no]"`
 	ManualMerge      bool   `env:"manual_merge,opt[yes,no]"`
-	AutoMerge        bool   `env:"auto_merge,opt[yes,no]"`
+	CheckoutMergedState        bool   `env:"checkout_merged_state,opt[yes,no]"`
 	FetchTags        bool   `env:"fetch_tags,opt[yes,no]"`
 	OptionsOnBranches bool 	`env:"options_on_branches,opt[yes,no]"`
 }
@@ -119,7 +119,7 @@ func mainE() error {
 			}
 		} else {
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
-				cfg.Commit, cfg.BranchDest, cfg.AutoMerge, cfg.CloneDepth, cfg.Tag != "", cfg.FetchTags, cfg.OptionsOnBranches); err != nil {
+				cfg.Commit, cfg.BranchDest, cfg.CheckoutMergedState, cfg.CloneDepth, cfg.Tag != "", cfg.FetchTags, cfg.OptionsOnBranches); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
 			}
 		}
@@ -128,7 +128,7 @@ func mainE() error {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.
-		if checkoutArg == cfg.Branch && cfg.AutoMerge{
+		if checkoutArg == cfg.Branch && cfg.CheckoutMergedState{
 			if err := run(gitCmd.Merge("origin/" + cfg.Branch)); err != nil {
 				return fmt.Errorf("merge %q: %v", cfg.Branch, err)
 			}

--- a/main.go
+++ b/main.go
@@ -127,7 +127,6 @@ func mainE() error {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.
-		log.Printf("ZZZ cfg.AutoMerge")
 		if checkoutArg == cfg.Branch && cfg.AutoMerge{
 			if err := run(gitCmd.Merge("origin/" + cfg.Branch)); err != nil {
 				return fmt.Errorf("merge %q: %v", cfg.Branch, err)

--- a/main.go
+++ b/main.go
@@ -127,7 +127,8 @@ func mainE() error {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.
-		if checkoutArg == cfg.Branch {
+		log.Printf("ZZZ cfg.AutoMerge")
+		if checkoutArg == cfg.Branch && cfg.AutoMerge{
 			if err := run(gitCmd.Merge("origin/" + cfg.Branch)); err != nil {
 				return fmt.Errorf("merge %q: %v", cfg.Branch, err)
 			}

--- a/main.go
+++ b/main.go
@@ -118,12 +118,12 @@ func mainE() error {
 			}
 		} else {
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
-				cfg.Commit, cfg.BranchDest, cfg.AutoMerge, cfg.CloneDepth, cfg.Tag != "", FetchTags); err != nil {
+				cfg.Commit, cfg.BranchDest, cfg.AutoMerge, cfg.CloneDepth, cfg.Tag != "", cfg.FetchTags); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
 			}
 		}
 	} else if checkoutArg != "" {
-		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != "", FetchTags); err != nil {
+		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != "", cfg.FetchTags); err != nil {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ type config struct {
 	UpdateSubmodules bool   `env:"update_submodules,opt[yes,no]"`
 	ManualMerge      bool   `env:"manual_merge,opt[yes,no]"`
 	AutoMerge        bool   `env:"auto_merge,opt[yes,no]"`
+	FetchTags        bool   `env:"fetch_tags,opt[yes,no]"`
 }
 
 const (
@@ -117,12 +118,12 @@ func mainE() error {
 			}
 		} else {
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
-				cfg.Commit, cfg.BranchDest, cfg.AutoMerge, cfg.CloneDepth, cfg.Tag != ""); err != nil {
+				cfg.Commit, cfg.BranchDest, cfg.AutoMerge, cfg.CloneDepth, cfg.Tag != "", fetch_tags); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
 			}
 		}
 	} else if checkoutArg != "" {
-		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != ""); err != nil {
+		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != "", fetch_tags); err != nil {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.

--- a/main.go
+++ b/main.go
@@ -116,10 +116,10 @@ func mainE() error {
 				cfg.BuildAPIToken, cfg.CloneDepth, cfg.PRID); err != nil {
 				return fmt.Errorf("auto merge, error: %v", err)
 			}
-		} else if cfg.AutoMerge {
+		} else {
 			log.Printf("YYY manualMerge")
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
-				cfg.Commit, cfg.BranchDest); err != nil {
+				cfg.Commit, cfg.BranchDest, cfg.AutoMerge); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -110,19 +110,21 @@ func mainE() error {
 	isPR := cfg.PRRepositoryURL != "" || cfg.PRMergeBranch != "" || cfg.PRID != 0
 	if isPR {
 		if !cfg.ManualMerge || isPrivate(cfg.PRRepositoryURL) && isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
-			log.Printf("XXX gitCmd.Merge")
+			log.Printf("YYY autoMerge")
 			if err := autoMerge(gitCmd, cfg.PRMergeBranch, cfg.BranchDest, cfg.BuildURL,
 				cfg.BuildAPIToken, cfg.CloneDepth, cfg.PRID); err != nil {
 				return fmt.Errorf("auto merge, error: %v", err)
 			}
 		} else {
-			log.Printf("YYY gitCmd.Merge")
+			log.Printf("YYY manualMerge")
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
 				cfg.Commit, cfg.BranchDest); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
 			}
 		}
 	} else if checkoutArg != "" {
+		
+		log.Printf("ZZZ checkout")
 		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != ""); err != nil {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func mainE() error {
 			}
 		}
 	} else if checkoutArg != "" {
-		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != "", cfg.FetchTags, cfg.OptionsOnBranches); err != nil {
+		if err := checkout(gitCmd, checkoutArg, cfg.Branch, cfg.CloneDepth, cfg.Tag != "", cfg.FetchTags); err != nil {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.

--- a/step.yml
+++ b/step.yml
@@ -135,6 +135,16 @@ inputs:
       value_options:
       - "yes"
       - "no"
+  - fetch_tags: "yes"
+    opts:
+      category: Debug
+      title: Fetch tags
+      summary: Adds --no-tags to fetch commands
+      description: |-
+        Adds --no-tags to fetch commands
+      value_options:
+      - "yes"
+      - "no"
   - build_url: "$BITRISE_BUILD_URL"
     opts:
       category: Debug

--- a/step.yml
+++ b/step.yml
@@ -124,6 +124,17 @@ inputs:
       value_options:
       - "yes"
       - "no"
+  - auto_merge: "yes"
+    opts:
+      category: Debug
+      title: Auto merge PRs to master
+      summary:  Merge PRs to master before building
+      description: |-
+        Merge PRs to master before building
+        Will fail build if PR cannot be merged
+      value_options:
+      - "yes"
+      - "no"
   - build_url: "$BITRISE_BUILD_URL"
     opts:
       category: Debug

--- a/step.yml
+++ b/step.yml
@@ -127,11 +127,10 @@ inputs:
   - auto_merge: "yes"
     opts:
       category: Debug
-      title: Auto merge PRs to master
-      summary:  Merge PRs to master before building
+      title: Merge origin/master
+      summary:  Merge origin/master 
       description: |-
-        Merge PRs to master before building
-        Will fail build if PR cannot be merged
+        Merge origin/master always
       value_options:
       - "yes"
       - "no"
@@ -142,6 +141,16 @@ inputs:
       summary: Adds --no-tags to fetch commands
       description: |-
         Adds --no-tags to fetch commands
+      value_options:
+      - "yes"
+      - "no"
+  - options_on_branches: "no"
+    opts:
+      category: Debug
+      title: Apply Clone Depth and Fetch Tags options to branches
+      summary: Apply Clone Depth and Fetch Tags options to branches
+      description: |-
+        Apply Clone Depth and Fetch Tags options to branches
       value_options:
       - "yes"
       - "no"

--- a/step.yml
+++ b/step.yml
@@ -130,7 +130,7 @@ inputs:
       title: Checkout merged state
       summary:  Flag indicating if merged state should be checked out instead of just the source branch.
       description: |-
-        Merge origin/master always
+        Flag indicating if merged state should be checked out instead of just the source branch.
       value_options:
       - "yes"
       - "no"

--- a/step.yml
+++ b/step.yml
@@ -124,11 +124,11 @@ inputs:
       value_options:
       - "yes"
       - "no"
-  - auto_merge: "yes"
+  - checkout_merged_state: "yes"
     opts:
       category: Debug
-      title: Merge origin/master
-      summary:  Merge origin/master 
+      title: Checkout merged state
+      summary:  Flag indicating if merged state should be checked out instead of just the source branch.
       description: |-
         Merge origin/master always
       value_options:


### PR DESCRIPTION
1. Not merging to master before building can significantly speed up the git clone. ie. git merge origin/master

2. Added the ability to optionally disable checking out tags 

3. Added the ability to apply clone depth and disable checkout tags to branches

New Settings:

![image](https://user-images.githubusercontent.com/60897705/91484383-fd730e80-e85d-11ea-9ac5-ef06c3d17a33.png)

All settings default to current functionality

This means when the step is updated nothing will change unless users change these 3 settings