### PR TITLE
Add option to disable merge origin/master

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -43,6 +43,7 @@ workflows:
     - _test_commit_logs
     - _test_hosted_git_notfork
     - _test_unrelated_histories
+    - _test_unrelated_histories_with_options
     - _test_hosted_git_ssh_prefix
 
   _test_submodule:
@@ -528,6 +529,40 @@ workflows:
         - branch: ""
         - clone_depth: "1"
         - manual_merge: "no"
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "GIT_CLONE_COMMIT_HASH: ${GIT_CLONE_COMMIT_HASH}"
+            echo "GIT_CLONE_COMMIT_MESSAGE_SUBJECT: ${GIT_CLONE_COMMIT_MESSAGE_SUBJECT}"
+            echo "GIT_CLONE_COMMIT_MESSAGE_BODY: ${GIT_CLONE_COMMIT_MESSAGE_BODY}"
+            echo "GIT_CLONE_COMMIT_COUNT: ${GIT_CLONE_COMMIT_COUNT}"
+            echo "GIT_CLONE_COMMIT_AUTHOR_NAME: ${GIT_CLONE_COMMIT_AUTHOR_NAME}"
+            echo "GIT_CLONE_COMMIT_AUTHOR_EMAIL: ${GIT_CLONE_COMMIT_AUTHOR_EMAIL}"
+            echo "GIT_CLONE_COMMIT_COMMITER_NAME: ${GIT_CLONE_COMMIT_COMMITER_NAME}"
+            echo "GIT_CLONE_COMMIT_COMMITER_EMAIL: ${GIT_CLONE_COMMIT_COMMITER_EMAIL}"
+    - ensure-clean-git:
+        inputs:
+        - dir_to_check: $CLONE_INTO_DIR
+
+  _test_unrelated_histories_with_options:
+    before_run:
+    - _create_tmpdir
+    steps:
+    - path::./:
+        run_if: true
+        inputs:
+        - clone_into_dir: $CLONE_INTO_DIR
+        - pull_request_id: 8
+        - pull_request_merge_branch: "pull/8/merge"
+        - pull_request_repository_url: $GIT_REPOSITORY_URL
+        - branch_dest: "unrelated-histories/master"
+        - commit: "62af44590c7a2b937726f2c3024a88a129b330b5"
+        - tag: ""
+        - branch: ""
+        - clone_depth: "50"
+        - manual_merge: "no"
+        - checkout_merged_state: "no"
     - script:
         inputs:
         - content: |-

--- a/git.go
+++ b/git.go
@@ -230,12 +230,18 @@ func autoMerge(gitCmd git.Git, mergeBranch, branchDest, buildURL, apiToken strin
 	return nil
 }
 
-func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string) error {
+func manualMerge(gitCmd git.Git, repoURL, prRepoURL, branch, commit, branchDest string, autoMerge bool) error {
 	if err := runWithRetry(func() *command.Model { return gitCmd.Fetch("origin", "refs/heads/"+branchDest) }); err != nil {
 		return fmt.Errorf("fetch failed, error: %v", err)
 	}
-	if err := pull(gitCmd, branchDest); err != nil {
-		return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)
+	if autoMerge {
+		if err := pull(gitCmd, branchDest); err != nil {
+			return fmt.Errorf("pull failed (%s), error: %v", branchDest, err)
+		}
+	} else {
+		if err := run(gitCmd.Checkout(branchDest)); err != nil {
+			return fmt.Errorf("checkout failed (%s), error: %v", branchDest, err)
+		}
 	}
 	commitHash, err := output(gitCmd.Log("%H"))
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ type config struct {
 	BuildAPIToken    string `env:"build_api_token"`
 	UpdateSubmodules bool   `env:"update_submodules,opt[yes,no]"`
 	ManualMerge      bool   `env:"manual_merge,opt[yes,no]"`
-	AutoMerge        bool   `env:"auto_merge,opt[yes,no]"`
+	CheckoutMergedState        bool   `env:"checkout_merged_state,opt[yes,no]"`
 }
 
 const (
@@ -117,7 +117,7 @@ func mainE() error {
 			}
 		} else {
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
-				cfg.Commit, cfg.BranchDest, cfg.AutoMerge); err != nil {
+				cfg.Commit, cfg.BranchDest, cfg.CheckoutMergedState); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
 			}
 		}
@@ -126,7 +126,7 @@ func mainE() error {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.
-		if checkoutArg == cfg.Branch && cfg.AutoMerge {
+		if checkoutArg == cfg.Branch && cfg.CheckoutMergedState {
 			if err := run(gitCmd.Merge("origin/" + cfg.Branch)); err != nil {
 				return fmt.Errorf("merge %q: %v", cfg.Branch, err)
 			}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type config struct {
 	BuildAPIToken    string `env:"build_api_token"`
 	UpdateSubmodules bool   `env:"update_submodules,opt[yes,no]"`
 	ManualMerge      bool   `env:"manual_merge,opt[yes,no]"`
+	AutoMerge        bool   `env:"auto_merge,opt[yes,no]"`
 }
 
 const (
@@ -116,7 +117,7 @@ func mainE() error {
 			}
 		} else {
 			if err := manualMerge(gitCmd, cfg.RepositoryURL, cfg.PRRepositoryURL, cfg.Branch,
-				cfg.Commit, cfg.BranchDest); err != nil {
+				cfg.Commit, cfg.BranchDest, cfg.AutoMerge); err != nil {
 				return fmt.Errorf("manual merge, error: %v", err)
 			}
 		}
@@ -125,7 +126,7 @@ func mainE() error {
 			return fmt.Errorf("checkout (%s): %v", checkoutArg, err)
 		}
 		// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.
-		if checkoutArg == cfg.Branch {
+		if checkoutArg == cfg.Branch && cfg.AutoMerge {
 			if err := run(gitCmd.Merge("origin/" + cfg.Branch)); err != nil {
 				return fmt.Errorf("merge %q: %v", cfg.Branch, err)
 			}

--- a/step.yml
+++ b/step.yml
@@ -124,6 +124,16 @@ inputs:
       value_options:
       - "yes"
       - "no"
+  - auto_merge: "yes"
+    opts:
+      category: Debug
+      title: Merge origin/master
+      summary:  Merge origin/master 
+      description: |-
+        Merge origin/master always
+      value_options:
+      - "yes"
+      - "no"
   - build_url: "$BITRISE_BUILD_URL"
     opts:
       category: Debug

--- a/step.yml
+++ b/step.yml
@@ -130,7 +130,7 @@ inputs:
       title: Checkout merged state
       summary:  Flag indicating if merged state should be checked out instead of just the source branch.
       description: |-
-        Merge origin/master always
+        Flag indicating if merged state should be checked out instead of just the source branch.
       value_options:
       - "yes"
       - "no"

--- a/step.yml
+++ b/step.yml
@@ -124,11 +124,11 @@ inputs:
       value_options:
       - "yes"
       - "no"
-  - auto_merge: "yes"
+  - checkout_merged_state: "yes"
     opts:
       category: Debug
-      title: Merge origin/master
-      summary:  Merge origin/master 
+      title: Checkout merged state
+      summary:  Flag indicating if merged state should be checked out instead of just the source branch.
       description: |-
         Merge origin/master always
       value_options:


### PR DESCRIPTION
Not merging to master before building can significantly speed up the git clone. ie. git merge origin/master

![image](https://user-images.githubusercontent.com/60897705/92270210-7c89c780-ee9a-11ea-815c-23e8f7263129.png)

All settings default to current functionality

This means when the step is updated nothing will change unless users changes this setting