### PR TITLE
Add branch recommendations to checkout errors [ACT-912]

### DIFF
--- a/gitclone/git_test.go
+++ b/gitclone/git_test.go
@@ -1,8 +1,12 @@
 package gitclone
 
 import (
+	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/bitrise-io/bitrise-init/errormapper"
+	"github.com/bitrise-io/bitrise-init/step"
 )
 
 func TestFetchArg(t *testing.T) {
@@ -92,6 +96,154 @@ func Test_parseListBranchesOutput(t *testing.T) {
 			got := parseListBranchesOutput(tt.args)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseListBranchesOutput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_handleCheckoutError(t *testing.T) {
+	type args struct {
+		callback func() (map[string][]string, error)
+		tag      string
+		err      error
+		shortMsg string
+		branch   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *step.Error
+	}{
+		{
+			name: "handleCheckoutError: generic error without branch recommendation",
+			args: args{
+				callback: func() (map[string][]string, error) { return nil, nil },
+				tag:      "fetch_failed",
+				err:      errors.New("Something bad happened"),
+				shortMsg: "Fetching repository has failed",
+				branch:   "",
+			},
+			want: &step.Error{
+				StepID:   "git-clone",
+				Tag:      "fetch_failed",
+				Err:      errors.New("Something bad happened"),
+				ShortMsg: "Fetching repository has failed",
+				Recommendations: step.Recommendation{
+					errormapper.DetailedErrorRecKey: errormapper.DetailedError{
+						Title:       "We couldn’t fetch your repository.",
+						Description: "Our auto-configurator returned the following error:\nSomething bad happened",
+					},
+				},
+			},
+		},
+		{
+			name: "handleCheckoutError: specific error with branch recommendations for default remote",
+			args: args{
+				callback: func() (map[string][]string, error) {
+					return map[string][]string{
+						defaultRemoteName: {"master", "develop"},
+					}, nil
+				},
+				tag:      "checkout_failed",
+				err:      errors.New("pathspec 'test' did not match any file(s) known to git"),
+				shortMsg: "Checkout has failed",
+				branch:   "test",
+			},
+			want: &step.Error{
+				StepID:   "git-clone",
+				Tag:      "checkout_failed",
+				Err:      errors.New("pathspec 'test' did not match any file(s) known to git"),
+				ShortMsg: "Checkout has failed",
+				Recommendations: step.Recommendation{
+					branchRecKey: []string{"master", "develop"},
+					errormapper.DetailedErrorRecKey: errormapper.DetailedError{
+						Title:       "We couldn't find the branch 'test'.",
+						Description: "Please choose another branch and try again.",
+					},
+				},
+			},
+		},
+		{
+			name: "handleCheckoutError: specific error without branch recommendations due to error",
+			args: args{
+				callback: func() (map[string][]string, error) {
+					return nil, errors.New("No available branches")
+				},
+				tag:      "checkout_failed",
+				err:      errors.New("pathspec 'test' did not match any file(s) known to git"),
+				shortMsg: "Checkout has failed",
+				branch:   "test",
+			},
+			want: &step.Error{
+				StepID:   "git-clone",
+				Tag:      "checkout_failed",
+				Err:      errors.New("pathspec 'test' did not match any file(s) known to git"),
+				ShortMsg: "Checkout has failed",
+				Recommendations: step.Recommendation{
+					errormapper.DetailedErrorRecKey: errormapper.DetailedError{
+						Title:       "We couldn't find the branch 'test'.",
+						Description: "Please choose another branch and try again.",
+					},
+				},
+			},
+		},
+		{
+			name: "handleCheckoutError: specific error without branch recommendations due correct branch",
+			args: args{
+				callback: func() (map[string][]string, error) {
+					return map[string][]string{
+						defaultRemoteName: {"master", "develop", "test"},
+					}, nil
+				},
+				tag:      "checkout_failed",
+				err:      errors.New("pathspec 'test' did not match any file(s) known to git"),
+				shortMsg: "Checkout has failed",
+				branch:   "test",
+			},
+			want: &step.Error{
+				StepID:   "git-clone",
+				Tag:      "checkout_failed",
+				Err:      errors.New("pathspec 'test' did not match any file(s) known to git"),
+				ShortMsg: "Checkout has failed",
+				Recommendations: step.Recommendation{
+					errormapper.DetailedErrorRecKey: errormapper.DetailedError{
+						Title:       "We couldn't find the branch 'test'.",
+						Description: "Please choose another branch and try again.",
+					},
+				},
+			},
+		},
+		{
+			name: "handleCheckoutError: specific error without branch recommendations for default remote",
+			args: args{
+				callback: func() (map[string][]string, error) {
+					return map[string][]string{
+						"something": {"master", "develop"},
+					}, nil
+				},
+				tag:      "checkout_failed",
+				err:      errors.New("pathspec 'test' did not match any file(s) known to git"),
+				shortMsg: "Checkout has failed",
+				branch:   "test",
+			},
+			want: &step.Error{
+				StepID:   "git-clone",
+				Tag:      "checkout_failed",
+				Err:      errors.New("pathspec 'test' did not match any file(s) known to git"),
+				ShortMsg: "Checkout has failed",
+				Recommendations: step.Recommendation{
+					errormapper.DetailedErrorRecKey: errormapper.DetailedError{
+						Title:       "We couldn't find the branch 'test'.",
+						Description: "Please choose another branch and try again.",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := handleCheckoutError(tt.args.callback, tt.args.tag, tt.args.err, tt.args.shortMsg, tt.args.branch); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handleCheckoutError() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/gitclone/steperror.go
+++ b/gitclone/steperror.go
@@ -7,6 +7,10 @@ import (
 	"github.com/bitrise-io/bitrise-init/step"
 )
 
+const (
+	branchRecKey = "BranchRecommendation"
+)
+
 func mapDetailedErrorRecommendation(tag, errMsg string) step.Recommendation {
 	switch tag {
 	case checkoutFailedTag:

--- a/gitclone/steperror.go
+++ b/gitclone/steperror.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bitrise-io/bitrise-init/step"
 )
 
-func mapRecommendation(tag, errMsg string) step.Recommendation {
+func mapDetailedErrorRecommendation(tag, errMsg string) step.Recommendation {
 	switch tag {
 	case checkoutFailedTag:
 		matcher := newCheckoutFailedPatternErrorMatcher()
@@ -15,16 +15,16 @@ func mapRecommendation(tag, errMsg string) step.Recommendation {
 	case updateSubmodelFailedTag: // update_submodule_failed could have the same errors as fetch
 		fallthrough
 	case fetchFailedTag:
-		fetchFailedMatcher := newFetchFailedPatternErrorMatcher()
-		return fetchFailedMatcher.Run(errMsg)
+		matcher := newFetchFailedPatternErrorMatcher()
+		return matcher.Run(errMsg)
 	}
 	return nil
 }
 
 func newStepError(tag string, err error, shortMsg string) *step.Error {
-	recommendation := mapRecommendation(tag, err.Error())
-	if recommendation != nil {
-		return step.NewErrorWithRecommendations("git-clone", tag, err, shortMsg, recommendation)
+	recommendations := mapDetailedErrorRecommendation(tag, err.Error())
+	if recommendations != nil {
+		return step.NewErrorWithRecommendations("git-clone", tag, err, shortMsg, recommendations)
 	}
 
 	return step.NewError("git-clone", tag, err, shortMsg)

--- a/gitclone/steperror_test.go
+++ b/gitclone/steperror_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bitrise-io/bitrise-init/step"
 )
 
-func Test_mapRecommendation(t *testing.T) {
+func Test_mapDetailedErrorRecommendation(t *testing.T) {
 	type args struct {
 		tag    string
 		errMsg string
@@ -252,7 +252,7 @@ func Test_mapRecommendation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := mapRecommendation(tt.args.tag, tt.args.errMsg); !reflect.DeepEqual(got, tt.want) {
+			if got := mapDetailedErrorRecommendation(tt.args.tag, tt.args.errMsg); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("mapRecommendation() = %v, want %v", got, tt.want)
 			}
 		})

--- a/gitclone/steperror_test.go
+++ b/gitclone/steperror_test.go
@@ -23,11 +23,22 @@ func Test_mapDetailedErrorRecommendation(t *testing.T) {
 			name: "checkout_failed generic error mapping",
 			args: args{
 				tag:    checkoutFailedTag,
-				errMsg: "error: pathspec 'master' did not match any file(s) known to git.",
+				errMsg: "error: fatal: /master: '/master' is outside repository",
 			},
 			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{
 				Title:       "We couldn’t checkout your branch.",
-				Description: "Our auto-configurator returned the following error:\nerror: pathspec 'master' did not match any file(s) known to git.",
+				Description: "Our auto-configurator returned the following error:\nerror: fatal: /master: '/master' is outside repository",
+			}),
+		},
+		{
+			name: "checkout_failed invalid banch error mapping",
+			args: args{
+				tag:    checkoutFailedTag,
+				errMsg: "error: pathspec 'master' did not match any file(s) known to git.",
+			},
+			want: errormapper.NewDetailedErrorRecommendation(errormapper.DetailedError{
+				Title:       "We couldn't find the branch 'master'.",
+				Description: "Please choose another branch and try again.",
 			}),
 		},
 		{
@@ -312,12 +323,13 @@ func Test_newStepError(t *testing.T) {
 	}
 }
 
-func Test_newStepErrorWithRecommendations(t *testing.T) {
+func Test_newStepErrorWithBranchRecommendations(t *testing.T) {
 	type args struct {
-		tag             string
-		err             error
-		shortMsg        string
-		recommendations step.Recommendation
+		tag               string
+		err               error
+		shortMsg          string
+		currentBranch     string
+		availableBranches []string
 	}
 	tests := []struct {
 		name string
@@ -325,30 +337,55 @@ func Test_newStepErrorWithRecommendations(t *testing.T) {
 		want *step.Error
 	}{
 		{
-			name: "newStepErrorWithRecommendations",
+			name: "newStepErrorWithBranchRecommendations without available branches",
 			args: args{
-				tag:      "test_tag",
-				err:      errors.New("fatal error"),
-				shortMsg: "unknown error",
-				recommendations: step.Recommendation{
-					"Test": "Passed",
-				},
+				tag:               "checkout_failed",
+				err:               errors.New("Generic error"),
+				shortMsg:          "Checkout has failed",
+				currentBranch:     "feature1",
+				availableBranches: nil,
 			},
 			want: &step.Error{
 				StepID:   "git-clone",
-				Tag:      "test_tag",
-				Err:      errors.New("fatal error"),
-				ShortMsg: "unknown error",
+				Tag:      "checkout_failed",
+				Err:      errors.New("Generic error"),
+				ShortMsg: "Checkout has failed",
 				Recommendations: step.Recommendation{
-					"Test": "Passed",
+					errormapper.DetailedErrorRecKey: errormapper.DetailedError{
+						Title:       "We couldn’t checkout your branch.",
+						Description: "Our auto-configurator returned the following error:\nGeneric error",
+					},
+				},
+			},
+		},
+		{
+			name: "newStepErrorWithBranchRecommendations with available branches",
+			args: args{
+				tag:               "checkout_failed",
+				err:               errors.New("pathspec 'feature1' did not match any file(s) known to git"),
+				shortMsg:          "Checkout has failed",
+				currentBranch:     "feature1",
+				availableBranches: []string{"master", "develop", "hotfix"},
+			},
+			want: &step.Error{
+				StepID:   "git-clone",
+				Tag:      "checkout_failed",
+				Err:      errors.New("pathspec 'feature1' did not match any file(s) known to git"),
+				ShortMsg: "Checkout has failed",
+				Recommendations: step.Recommendation{
+					branchRecKey: []string{"master", "develop", "hotfix"},
+					errormapper.DetailedErrorRecKey: errormapper.DetailedError{
+						Title:       "We couldn't find the branch 'feature1'.",
+						Description: "Please choose another branch and try again.",
+					},
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := newStepErrorWithRecommendations(tt.args.tag, tt.args.err, tt.args.shortMsg, tt.args.recommendations); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("newStepErrorWithRecommendations() = %v, want %v", got, tt.want)
+			if got := newStepErrorWithBranchRecommendations(tt.args.tag, tt.args.err, tt.args.shortMsg, tt.args.currentBranch, tt.args.availableBranches); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newStepErrorWithBranchRecommendations() = %v,want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/ACT-912

- Map checkout error:
`pathspec '{{branchName}}' did not match any file(s) known to git` -> 
```
We couldn't find the branch '{{branchName}}'.
Please choose another branch and try again.
```

- Provide available branch recommendations if available