### PR TITLE
Implement fallback to manual merge upon failing on apply

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -32,13 +32,12 @@ workflows:
     envs:
     - CLONE_INTO_DIR: .
     - GIT_REPOSITORY_URL: https://github.com/bitrise-io/git-clone-test.git
+    before_run:
+    - audit-this-step
+    - go-tests
     steps:
     - activate-ssh-key:
         run_if: true
-    - go-list:
-    - golint:
-    - errcheck:
-    - go-test:
     after_run:
     - _test_error
     - _test_submodule
@@ -60,6 +59,13 @@ workflows:
     - _test_unrelated_histories
     - _test_hosted_git_ssh_prefix
     - test_diff_file
+
+  go-tests:
+    steps:
+    - go-list:
+    - golint:
+    - errcheck:
+    - go-test:
 
   _test_submodule:
     before_run:
@@ -686,8 +692,6 @@ workflows:
         inputs:
         - path: $STEP_TMPDIR
 
-  # ----------------------------------------------------------------
-  # --- workflow to Share this step into a Step Library
   audit-this-step:
     steps:
     - script:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -635,7 +635,7 @@ workflows:
         - pull_request_merge_branch: ""
         - branch_dest: "master"
         - branch: "master"
-        - commit: "commit"
+        - commit: "c6810e6"
         - tag: ""
         - clone_depth: "1"
         - manual_merge: "no"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,8 +12,8 @@ app:
       echo "GIT_CLONE_COMMIT_AUTHOR_EMAIL: ${GIT_CLONE_COMMIT_AUTHOR_EMAIL}"
       echo "GIT_CLONE_COMMIT_COMMITER_NAME: ${GIT_CLONE_COMMIT_COMMITER_NAME}"
       echo "GIT_CLONE_COMMIT_COMMITER_EMAIL: ${GIT_CLONE_COMMIT_COMMITER_EMAIL}"
-      opts:
-    is_expand: false
+    opts:
+      is_expand: false
   # define these envs in your .bitrise.secrets.yml
   - SSH_RSA_PRIVATE_KEY: $SSH_RSA_PRIVATE_KEY
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,19 +3,19 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-    - STEP_ID_IN_STEPLIB: git-clone
-    - GIT_REPOSITORY_URL: https://github.com/bitrise-io/steps-git-clone.git
-    - opts:
-        is_expand: false
-      EVAL_SCRIPT: |-
-        echo "GIT_CLONE_COMMIT_HASH: ${GIT_CLONE_COMMIT_HASH}"
-        echo "GIT_CLONE_COMMIT_MESSAGE_SUBJECT: ${GIT_CLONE_COMMIT_MESSAGE_SUBJECT}"
-        echo "GIT_CLONE_COMMIT_MESSAGE_BODY: ${GIT_CLONE_COMMIT_MESSAGE_BODY}"
-        echo "GIT_CLONE_COMMIT_COUNT: ${GIT_CLONE_COMMIT_COUNT}"
-        echo "GIT_CLONE_COMMIT_AUTHOR_NAME: ${GIT_CLONE_COMMIT_AUTHOR_NAME}"
-        echo "GIT_CLONE_COMMIT_AUTHOR_EMAIL: ${GIT_CLONE_COMMIT_AUTHOR_EMAIL}"
-        echo "GIT_CLONE_COMMIT_COMMITER_NAME: ${GIT_CLONE_COMMIT_COMMITER_NAME}"
-        echo "GIT_CLONE_COMMIT_COMMITER_EMAIL: ${GIT_CLONE_COMMIT_COMMITER_EMAIL}"
+  - EVAL_SCRIPT: |-
+      echo "GIT_CLONE_COMMIT_HASH: ${GIT_CLONE_COMMIT_HASH}"
+      echo "GIT_CLONE_COMMIT_MESSAGE_SUBJECT: ${GIT_CLONE_COMMIT_MESSAGE_SUBJECT}"
+      echo "GIT_CLONE_COMMIT_MESSAGE_BODY: ${GIT_CLONE_COMMIT_MESSAGE_BODY}"
+      echo "GIT_CLONE_COMMIT_COUNT: ${GIT_CLONE_COMMIT_COUNT}"
+      echo "GIT_CLONE_COMMIT_AUTHOR_NAME: ${GIT_CLONE_COMMIT_AUTHOR_NAME}"
+      echo "GIT_CLONE_COMMIT_AUTHOR_EMAIL: ${GIT_CLONE_COMMIT_AUTHOR_EMAIL}"
+      echo "GIT_CLONE_COMMIT_COMMITER_NAME: ${GIT_CLONE_COMMIT_COMMITER_NAME}"
+      echo "GIT_CLONE_COMMIT_COMMITER_EMAIL: ${GIT_CLONE_COMMIT_COMMITER_EMAIL}"
+      opts:
+    is_expand: false
+  # define these envs in your .bitrise.secrets.yml
+  - SSH_RSA_PRIVATE_KEY: $SSH_RSA_PRIVATE_KEY
 
 workflows:
   test:
@@ -53,7 +53,7 @@ workflows:
     - _test_checkout_pull_request_with_depth
     - _test_unshallow
     - _test_checkout_different_dir
-    - _test_manual_merge_ignore_depth
+    - _test_manual_merge_unshallow
     - _test_commit_logs
     - _test_hosted_git_notfork
     - _test_unrelated_histories
@@ -412,7 +412,7 @@ workflows:
         inputs:
         - dir_to_check: $CLONE_INTO_DIR
 
-  _test_manual_merge_ignore_depth:
+  _test_manual_merge_unshallow:
     before_run:
     - _create_tmpdir
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -635,7 +635,7 @@ workflows:
         - pull_request_merge_branch: ""
         - branch_dest: "master"
         - branch: "master"
-        - commit: ""
+        - commit: "commit"
         - tag: ""
         - clone_depth: "1"
         - manual_merge: "no"

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -193,28 +193,21 @@ func createCheckoutStrategy(checkoutMethod CheckoutMethod, cfg Config, patch pat
 
 }
 
-func selectFetchOptions(checkoutStrategy CheckoutMethod, cloneDepth int, isTag bool) fetchOptions {
+func selectFetchOptions(checkoutStrategy CheckoutMethod, cloneDepth int, fetchAllTags bool) fetchOptions {
+	opts := fetchOptions{
+		depth:   cloneDepth,
+		allTags: false,
+	}
+
 	switch checkoutStrategy {
 	case CheckoutCommitMethod, CheckoutBranchMethod:
-		return fetchOptions{
-			depth:   cloneDepth,
-			allTags: isTag,
-		}
+		opts.allTags = fetchAllTags
 	case CheckoutTagMethod:
-		return fetchOptions{
-			depth:   cloneDepth,
-			allTags: true,
-		}
-	case CheckoutPRMergeBranchMethod, CheckoutPRDiffFileMethod:
-		return fetchOptions{
-			depth:   cloneDepth,
-			allTags: false,
-		}
-	case CheckoutPRManualMergeMethod, CheckoutForkPRManualMergeMethod, CheckoutNoneMethod:
-		return fetchOptions{}
+		opts.allTags = true
 	default:
-		return fetchOptions{}
 	}
+
+	return opts
 }
 
 func selectFallbacks(checkoutStrategy CheckoutMethod, fetchOpts fetchOptions) fallbackRetry {

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -160,9 +160,14 @@ func createCheckoutStrategy(checkoutMethod CheckoutMethod, cfg Config, patch pat
 				return nil, fmt.Errorf("merging PR (automatic) failed, there is no Pull Request branch and could not download diff file: %v", err)
 			}
 
+			params, err := NewPRDiffFileParams(cfg.BranchDest)
+			if err != nil {
+				return nil, err
+			}
+
 			return checkoutPRDiffFile{
-				baseBranch: cfg.BranchDest,
-				patchFile:  patchFile,
+				params:    *params,
+				patchFile: patchFile,
 			}, nil
 		}
 	case CheckoutForkPRManualMergeMethod:

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -240,5 +240,5 @@ func createManualMergeParams(cfg Config) (prManualMergeParam *PRManualMergeParam
  	} else {
  		prManualMergeParam, err = NewPRManualMergeParams(cfg.Branch, cfg.Commit, cfg.BranchDest)
  	}
-    return
+	return
 }

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -240,5 +240,5 @@ func createManualMergeParams(cfg Config) (prManualMergeParam *PRManualMergeParam
  	} else {
  		prManualMergeParam, err = NewPRManualMergeParams(cfg.Branch, cfg.Commit, cfg.BranchDest)
  	}
-       return
+    return
 }

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -234,16 +234,11 @@ func selectFallbacks(checkoutStrategy CheckoutMethod, fetchOpts fetchOptions) fa
 	}
 }
 
-func createManualMergeParams(cfg Config) (*PRManualMergeParams, *ForkPRManualMergeParams, error) {
-	var prManualMergeParam *PRManualMergeParams
-	var forkPRManualMergeParam *ForkPRManualMergeParams
-	var err error
-
+func createManualMergeParams(cfg Config) (prManualMergeParam *PRManualMergeParams, forkPRManualMergeParam *ForkPRManualMergeParams, err error) {
 	if isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
-		forkPRManualMergeParam, err = NewForkPRManualMergeParams(cfg.Branch, cfg.PRRepositoryURL, cfg.BranchDest)
-	} else {
-		prManualMergeParam, err = NewPRManualMergeParams(cfg.Branch, cfg.Commit, cfg.BranchDest)
-	}
-
-	return prManualMergeParam, forkPRManualMergeParam, err
+ 		forkPRManualMergeParam, err = NewForkPRManualMergeParams(cfg.Branch, cfg.PRRepositoryURL, cfg.BranchDest)
+ 	} else {
+ 		prManualMergeParam, err = NewPRManualMergeParams(cfg.Branch, cfg.Commit, cfg.BranchDest)
+ 	}
+       return
 }

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -216,25 +216,15 @@ func selectFetchOptions(checkoutStrategy CheckoutMethod, cloneDepth int, fetchAl
 }
 
 func selectFallbacks(checkoutStrategy CheckoutMethod, fetchOpts fetchOptions) fallbackRetry {
-	switch checkoutStrategy {
-	case CheckoutCommitMethod, CheckoutTagMethod:
-		{
-			if !fetchOpts.IsFullDepth() {
-				return simpleUnshallow{}
-			}
-
-			return nil
-		}
-	case CheckoutPRMergeBranchMethod:
-		{
-			if !fetchOpts.IsFullDepth() {
-				return resetUnshallow{}
-			}
-
-			return nil
-		}
-	case CheckoutPRManualMergeMethod, CheckoutForkPRManualMergeMethod, CheckoutBranchMethod, CheckoutPRDiffFileMethod:
+	if fetchOpts.IsFullDepth() {
 		return nil
+	}
+
+	switch checkoutStrategy {
+	case CheckoutCommitMethod, CheckoutTagMethod, CheckoutBranchMethod:
+		return simpleUnshallow{}
+	case CheckoutPRMergeBranchMethod, CheckoutPRManualMergeMethod, CheckoutForkPRManualMergeMethod, CheckoutPRDiffFileMethod:
+		return resetUnshallow{}
 	default:
 		return nil
 	}

--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -136,7 +136,7 @@ func mergeWithCustomRetry(gitCmd git.Git, arg string, retry fallbackRetry) error
 
 func fetchAndMerge(gitCmd git.Git, fetchParam fetchParams, mergeParam mergeParams) error {
 	headBranchRef := branchRefPrefix + fetchParam.branch
-	if err := fetch(gitCmd, fetchParam.remote, &headBranchRef, fetchParam.options); err != nil {
+	if err := fetch(gitCmd, fetchParam.remote, headBranchRef, fetchParam.options); err != nil {
 		return nil
 	}
 

--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -37,7 +37,6 @@ func (t fetchOptions) IsFullDepth() bool {
 }
 
 const branchRefPrefix = "refs/heads/"
-const forkRemoteName = "fork"
 
 func fetch(gitCmd git.Git, remote string, ref string, traits fetchOptions) error {
 	var opts []string
@@ -106,7 +105,7 @@ func fetchInitialBranch(gitCmd git.Git, remote string, branchRef string, fetchTr
 	}
 
 	// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.
-	remoteBranch := fmt.Sprintf("%s/%s", defaultRemoteName, branch)
+	remoteBranch := fmt.Sprintf("%s/%s", originRemoteName, branch)
 	if err := runner.Run(gitCmd.Merge(remoteBranch)); err != nil {
 		return newStepError(
 			"update_branch_failed",
@@ -142,14 +141,6 @@ func fetchAndMerge(gitCmd git.Git, fetchParam fetchParams, mergeParam mergeParam
 	}
 
 	return mergeWithCustomRetry(gitCmd, mergeParam.arg, mergeParam.fallback)
-}
-
-func addForkRemote(gitCmd git.Git, repoURL string) error {
-	if err := runner.Run(gitCmd.RemoteAdd(forkRemoteName, repoURL)); err != nil {
-		return fmt.Errorf("adding remote fork repository failed (%s): %v", repoURL, err)
-	}
-
-	return nil
 }
 
 func detachHead(gitCmd git.Git) error {

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -46,7 +46,7 @@ type checkoutPRDiffFile struct {
 
 func (c checkoutPRDiffFile) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
 	baseBranchRef := branchRefPrefix + c.params.BaseBranch
-	if err := fetch(gitCmd, originRemoteName, &baseBranchRef, fetchOptions); err != nil {
+	if err := fetch(gitCmd, originRemoteName, baseBranchRef, fetchOptions); err != nil {
 		return err
 	}
 

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -18,8 +18,8 @@ type PRDiffFileParams struct {
 	BaseBranch string
 }
 
-// NewPRDiffFileParams validates and returns a new PRDiffFile
-func NewPRDiffFileParams(baseBranch string, PRID uint) (*PRDiffFileParams, error) {
+// NewPRDiffFileParams validates and returns a new PRDiffFileParams
+func NewPRDiffFileParams(baseBranch string) (*PRDiffFileParams, error) {
 	if strings.TrimSpace(baseBranch) == "" {
 		return nil, NewParameterValidationError("PR diff file based checkout strategy can not be used: no base branch specified")
 	}
@@ -31,16 +31,17 @@ func NewPRDiffFileParams(baseBranch string, PRID uint) (*PRDiffFileParams, error
 
 // checkoutPRDiffFile
 type checkoutPRDiffFile struct {
-	baseBranch, patchFile string
+	params    PRDiffFileParams
+	patchFile string
 }
 
 func (c checkoutPRDiffFile) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
-	baseBranchRef := branchRefPrefix + c.baseBranch
+	baseBranchRef := branchRefPrefix + c.params.BaseBranch
 	if err := fetch(gitCmd, defaultRemoteName, &baseBranchRef, fetchOptions); err != nil {
 		return err
 	}
 
-	if err := checkoutWithCustomRetry(gitCmd, c.baseBranch, fallback); err != nil {
+	if err := checkoutWithCustomRetry(gitCmd, c.params.BaseBranch, fallback); err != nil {
 		return err
 	}
 

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -46,7 +46,7 @@ type checkoutPRDiffFile struct {
 
 func (c checkoutPRDiffFile) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
 	baseBranchRef := branchRefPrefix + c.params.BaseBranch
-	if err := fetch(gitCmd, defaultRemoteName, baseBranchRef, fetchOptions); err != nil {
+	if err := fetch(gitCmd, originRemoteName, &baseBranchRef, fetchOptions); err != nil {
 		return err
 	}
 
@@ -104,7 +104,7 @@ func fallbackToManualMergeOnApplyError(
 	if prManualMergeParam != nil {
 		fetchParam = fetchParams{
 			branch:  prManualMergeParam.HeadBranch,
-			remote:  defaultRemoteName,
+			remote:  originRemoteName,
 			options: fetchOptions,
 		}
 
@@ -113,9 +113,8 @@ func fallbackToManualMergeOnApplyError(
 			fallback: fallback,
 		}
 	} else if forkPRManualMergeParam != nil {
-		err := addForkRemote(gitCmd, forkPRManualMergeParam.HeadRepoURL)
-		if err != nil {
-			return err
+		if err := runner.Run(gitCmd.RemoteAdd(forkRemoteName, forkPRManualMergeParam.HeadRepoURL)); err != nil {
+			return fmt.Errorf("adding remote fork repository failed (%s): %v", forkPRManualMergeParam.HeadRepoURL, err)
 		}
 
 		fetchParam = fetchParams{

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -15,17 +15,25 @@ import (
 //
 // PRDiffFileParams are parameters to check out a Merge/Pull Request (when a diff file is available)
 type PRDiffFileParams struct {
-	BaseBranch string
+	BaseBranch             string
+	PRManualMergeParam     *PRManualMergeParams
+	ForkPRManualMergeParam *ForkPRManualMergeParams
 }
 
 // NewPRDiffFileParams validates and returns a new PRDiffFileParams
-func NewPRDiffFileParams(baseBranch string) (*PRDiffFileParams, error) {
+func NewPRDiffFileParams(
+	baseBranch string,
+	prManualMergeParam *PRManualMergeParams,
+	forkPRManualMergeParam *ForkPRManualMergeParams,
+) (*PRDiffFileParams, error) {
 	if strings.TrimSpace(baseBranch) == "" {
 		return nil, NewParameterValidationError("PR diff file based checkout strategy can not be used: no base branch specified")
 	}
 
 	return &PRDiffFileParams{
-		BaseBranch: baseBranch,
+		BaseBranch:             baseBranch,
+		PRManualMergeParam:     prManualMergeParam,
+		ForkPRManualMergeParam: forkPRManualMergeParam,
 	}, nil
 }
 
@@ -46,6 +54,7 @@ func (c checkoutPRDiffFile) do(gitCmd git.Git, fetchOptions fetchOptions, fallba
 	}
 
 	if err := runner.Run(gitCmd.Apply(c.patchFile)); err != nil {
+
 		return fmt.Errorf("could not apply patch (%s): %v", c.patchFile, err)
 	}
 

--- a/gitclone/checkout_method_pr_auto_merge_branch.go
+++ b/gitclone/checkout_method_pr_auto_merge_branch.go
@@ -44,7 +44,7 @@ func (c checkoutPRMergeBranch) do(gitCmd git.Git, fetchOpts fetchOptions, fallba
 
 	// `git "fetch" "origin" "refs/pull/7/head:pull/7"`
 	headBranchRef := fetchArg(c.params.MergeBranch)
-	if err := fetch(gitCmd, defaultRemoteName, &headBranchRef, fetchOptions{}); err != nil {
+	if err := fetch(gitCmd, defaultRemoteName, &headBranchRef, fetchOpts); err != nil {
 		return err
 	}
 

--- a/gitclone/checkout_method_pr_auto_merge_branch.go
+++ b/gitclone/checkout_method_pr_auto_merge_branch.go
@@ -38,13 +38,13 @@ func (c checkoutPRMergeBranch) do(gitCmd git.Git, fetchOpts fetchOptions, fallba
 	// Check out initial branch (fetchInitialBranch part1)
 	// `git "fetch" "origin" "refs/heads/master"`
 	baseBranchRef := branchRefPrefix + c.params.BaseBranch
-	if err := fetch(gitCmd, defaultRemoteName, baseBranchRef, fetchOpts); err != nil {
+	if err := fetch(gitCmd, originRemoteName, &baseBranchRef, fetchOpts); err != nil {
 		return err
 	}
 
 	// `git "fetch" "origin" "refs/pull/7/head:pull/7"`
 	headBranchRef := fetchArg(c.params.MergeBranch)
-	if err := fetch(gitCmd, defaultRemoteName, headBranchRef, fetchOpts); err != nil {
+	if err := fetch(gitCmd, originRemoteName, &headBranchRef, fetchOpts); err != nil {
 		return err
 	}
 
@@ -54,7 +54,7 @@ func (c checkoutPRMergeBranch) do(gitCmd git.Git, fetchOpts fetchOptions, fallba
 	if err := checkoutWithCustomRetry(gitCmd, c.params.BaseBranch, nil); err != nil {
 		return err
 	}
-	remoteBaseBranch := fmt.Sprintf("%s/%s", defaultRemoteName, c.params.BaseBranch)
+	remoteBaseBranch := fmt.Sprintf("%s/%s", originRemoteName, c.params.BaseBranch)
 	if err := runner.Run(gitCmd.Merge(remoteBaseBranch)); err != nil {
 		return err
 	}

--- a/gitclone/checkout_method_pr_auto_merge_branch.go
+++ b/gitclone/checkout_method_pr_auto_merge_branch.go
@@ -38,13 +38,13 @@ func (c checkoutPRMergeBranch) do(gitCmd git.Git, fetchOpts fetchOptions, fallba
 	// Check out initial branch (fetchInitialBranch part1)
 	// `git "fetch" "origin" "refs/heads/master"`
 	baseBranchRef := branchRefPrefix + c.params.BaseBranch
-	if err := fetch(gitCmd, originRemoteName, &baseBranchRef, fetchOpts); err != nil {
+	if err := fetch(gitCmd, originRemoteName, baseBranchRef, fetchOpts); err != nil {
 		return err
 	}
 
 	// `git "fetch" "origin" "refs/pull/7/head:pull/7"`
 	headBranchRef := fetchArg(c.params.MergeBranch)
-	if err := fetch(gitCmd, originRemoteName, &headBranchRef, fetchOpts); err != nil {
+	if err := fetch(gitCmd, originRemoteName, headBranchRef, fetchOpts); err != nil {
 		return err
 	}
 

--- a/gitclone/checkout_method_pr_manual.go
+++ b/gitclone/checkout_method_pr_manual.go
@@ -44,7 +44,7 @@ type checkoutPRManualMerge struct {
 func (c checkoutPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
 	// Fetch and checkout base (target) branch
 	baseBranchRef := branchRefPrefix + c.params.BaseBranch
-	if err := fetchInitialBranch(gitCmd, defaultRemoteName, baseBranchRef, fetchOptions); err != nil {
+	if err := fetchInitialBranch(gitCmd, originRemoteName, baseBranchRef, fetchOptions); err != nil {
 		return err
 	}
 
@@ -56,7 +56,7 @@ func (c checkoutPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fal
 
 	// Fetch and merge
 	headBranchRef := branchRefPrefix + c.params.HeadBranch
-	if err := fetch(gitCmd, defaultRemoteName, headBranchRef, fetchOptions); err != nil {
+	if err := fetch(gitCmd, originRemoteName, &headBranchRef, fetchOptions); err != nil {
 		return nil
 	}
 
@@ -103,7 +103,7 @@ type checkoutForkPRManualMerge struct {
 func (c checkoutForkPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
 	// Fetch and checkout base branch
 	baseBranchRef := branchRefPrefix + c.params.BaseBranch
-	if err := fetchInitialBranch(gitCmd, defaultRemoteName, baseBranchRef, fetchOptions); err != nil {
+	if err := fetchInitialBranch(gitCmd, originRemoteName, baseBranchRef, fetchOptions); err != nil {
 		return err
 	}
 

--- a/gitclone/checkout_method_pr_manual.go
+++ b/gitclone/checkout_method_pr_manual.go
@@ -56,7 +56,7 @@ func (c checkoutPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fal
 
 	// Fetch and merge
 	headBranchRef := branchRefPrefix + c.params.HeadBranch
-	if err := fetch(gitCmd, originRemoteName, &headBranchRef, fetchOptions); err != nil {
+	if err := fetch(gitCmd, originRemoteName, headBranchRef, fetchOptions); err != nil {
 		return nil
 	}
 

--- a/gitclone/checkout_method_simple.go
+++ b/gitclone/checkout_method_simple.go
@@ -39,12 +39,9 @@ type checkoutCommit struct {
 }
 
 func (c checkoutCommit) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
-	branchRefParam := ""
-	if c.params.Branch != "" {
-		branchRefParam = branchRefPrefix + c.params.Branch
-	}
-
-	if err := fetch(gitCmd, defaultRemoteName, branchRefParam, fetchOptions); err != nil {
+	// Fetch then checkout
+	// No branch specified for fetch
+	if err := fetch(gitCmd, originRemoteName, nil, fetchOptions); err != nil {
 		return err
 	}
 
@@ -79,7 +76,7 @@ type checkoutBranch struct {
 
 func (c checkoutBranch) do(gitCmd git.Git, fetchOptions fetchOptions, _ fallbackRetry) error {
 	branchRef := branchRefPrefix + c.params.Branch
-	if err := fetchInitialBranch(gitCmd, defaultRemoteName, branchRef, fetchOptions); err != nil {
+	if err := fetchInitialBranch(gitCmd, originRemoteName, branchRef, fetchOptions); err != nil {
 		return err
 	}
 
@@ -116,7 +113,7 @@ func (c checkoutTag) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fall
 		branchRefParam = branchRefPrefix + c.params.Branch
 	}
 
-	if err := fetch(gitCmd, defaultRemoteName, branchRefParam, fetchOptions); err != nil {
+	if err := fetch(gitCmd, originRemoteName, branchRefParam, fetchOptions); err != nil {
 		return err
 	}
 

--- a/gitclone/checkout_method_simple.go
+++ b/gitclone/checkout_method_simple.go
@@ -39,9 +39,12 @@ type checkoutCommit struct {
 }
 
 func (c checkoutCommit) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
-	// Fetch then checkout
-	// No branch specified for fetch
-	if err := fetch(gitCmd, originRemoteName, nil, fetchOptions); err != nil {
+	branchRefParam := ""
+	if c.params.Branch != "" {
+		branchRefParam = branchRefPrefix + c.params.Branch
+	}
+
+	if err := fetch(gitCmd, originRemoteName, branchRefParam, fetchOptions); err != nil {
 		return err
 	}
 

--- a/gitclone/git.go
+++ b/gitclone/git.go
@@ -157,7 +157,7 @@ func handleCheckoutError(callback getAvailableBranches, tag string, err error, s
 	// We were checking out a branch (not tag or commit)
 	if branch != "" {
 		branchesByRemote, branchesErr := callback()
-		branches := branchesByRemote[defaultRemoteName]
+		branches := branchesByRemote[originRemoteName]
 		// There was no error grabbing the available branches
 		// And the current branch is not present in the list
 		if branchesErr == nil && !sliceutil.IsStringInSlice(branch, branches) {

--- a/gitclone/git_test.go
+++ b/gitclone/git_test.go
@@ -141,7 +141,7 @@ func Test_handleCheckoutError(t *testing.T) {
 			args: args{
 				callback: func() (map[string][]string, error) {
 					return map[string][]string{
-						defaultRemoteName: {"master", "develop"},
+						originRemoteName: {"master", "develop"},
 					}, nil
 				},
 				tag:      "checkout_failed",
@@ -192,7 +192,7 @@ func Test_handleCheckoutError(t *testing.T) {
 			args: args{
 				callback: func() (map[string][]string, error) {
 					return map[string][]string{
-						defaultRemoteName: {"master", "develop", "test"},
+						originRemoteName: {"master", "develop", "test"},
 					}, nil
 				},
 				tag:      "checkout_failed",

--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -32,8 +32,9 @@ type Config struct {
 
 const (
 	trimEnding              = "..."
-	defaultRemoteName       = "origin"
+	originRemoteName       = "origin"
 	updateSubmodelFailedTag = "update_submodule_failed"
+	forkRemoteName = "fork"
 )
 
 func printLogAndExportEnv(gitCmd git.Git, format, env string, maxEnvLength int) error {
@@ -130,7 +131,7 @@ func Execute(cfg Config) error {
 		)
 	}
 	if !originPresent {
-		if err := runner.Run(gitCmd.RemoteAdd(defaultRemoteName, cfg.RepositoryURL)); err != nil {
+		if err := runner.Run(gitCmd.RemoteAdd(originRemoteName, cfg.RepositoryURL)); err != nil {
 			return newStepError(
 				"add_remote_failed",
 				fmt.Errorf("adding remote repository failed (%s): %v", cfg.RepositoryURL, err),

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -284,7 +284,7 @@ var testCases = [...]struct {
 			BranchDest:    "master",
 			PRID:          7,
 			ManualMerge:   false,
-			Commit:        "76a934ae", // TODO
+			Commit:        "76a934ae",
 			CloneDepth:    1,
 		},
 		patchSource: MockPatchSource{"diff_path", nil},
@@ -304,7 +304,7 @@ var testCases = [...]struct {
 			BranchDest:    "master",
 			PRID:          7,
 			ManualMerge:   false,
-			Commit:        "76a934ae", // TODO
+			Commit:        "76a934ae",
 			CloneDepth:    1,
 		},
 		patchSource: MockPatchSource{"diff_path", nil},
@@ -327,7 +327,7 @@ var testCases = [...]struct {
 			PRRepositoryURL: "git@github.com:bitrise-io/other-repo.git",
 			Branch:          "test/commit-messages",
 			BranchDest:      "master",
-			Commit:          "76a934ae", // TODO
+			Commit:          "76a934ae",
 			ManualMerge:     true,
 		},
 		patchSource: MockPatchSource{"diff_path", nil},

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -29,10 +29,11 @@ var testCases = [...]struct {
 	{
 		name: "Checkout commit",
 		cfg: Config{
-			Commit: "76a934a",
+			Commit:     "76a934a",
+			CloneDepth: 1,
 		},
 		wantCmds: []string{
-			`git "fetch"`,
+			`git "fetch" "--depth=1"`,
 			`git "checkout" "76a934a"`,
 		},
 	},
@@ -62,10 +63,11 @@ var testCases = [...]struct {
 	{
 		name: "Checkout branch",
 		cfg: Config{
-			Branch: "hcnarb",
+			Branch:     "hcnarb",
+			CloneDepth: 1,
 		},
 		wantCmds: []string{
-			`git "fetch" "origin" "refs/heads/hcnarb"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/hcnarb"`,
 			`git "checkout" "hcnarb"`,
 			`git "merge" "origin/hcnarb"`,
 		},
@@ -73,10 +75,11 @@ var testCases = [...]struct {
 	{
 		name: "Checkout tag",
 		cfg: Config{
-			Tag: "gat",
+			Tag:        "gat",
+			CloneDepth: 1,
 		},
 		wantCmds: []string{
-			`git "fetch" "--tags"`,
+			`git "fetch" "--depth=1" "--tags"`,
 			`git "checkout" "gat"`,
 		},
 	},
@@ -128,7 +131,7 @@ var testCases = [...]struct {
 
 	// ** PRs manual merge
 	{
-		name: "PR - no fork - manual merge: branch and commit (ignore depth)",
+		name: "PR - no fork - manual merge: branch and commit",
 		cfg: Config{
 			Commit:        "76a934ae",
 			Branch:        "test/commit-messages",
@@ -139,11 +142,11 @@ var testCases = [...]struct {
 			ManualMerge:   true,
 		},
 		wantCmds: []string{
-			`git "fetch" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,     // Already on 'master'
 			`git "merge" "origin/master"`, // Already up to date.
 			`git "log" "-1" "--format=%H"`,
-			`git "fetch" "origin" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
 			`git "checkout" "--detach"`,
 		},
@@ -154,11 +157,10 @@ var testCases = [...]struct {
 			Commit:      "76a934ae",
 			Branch:      "test/commit-messages",
 			BranchDest:  "master",
-			CloneDepth:  1,
 			ManualMerge: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1"`,
+			`git "fetch"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -171,14 +173,15 @@ var testCases = [...]struct {
 			BranchDest:      "master",
 			Commit:          "76a934ae",
 			ManualMerge:     true,
+			CloneDepth:      1,
 		},
 		wantCmds: []string{
-			`git "fetch" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
 			`git "remote" "add" "fork" "https://github.com/bitrise-io/other-repo.git"`,
-			`git "fetch" "fork" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--depth=1" "fork" "refs/heads/test/commit-messages"`,
 			`git "merge" "fork/test/commit-messages"`,
 			`git "checkout" "--detach"`,
 		},
@@ -212,10 +215,11 @@ var testCases = [...]struct {
 		cfg: Config{
 			BranchDest:    "master",
 			PRMergeBranch: "pull/5/merge",
+			CloneDepth:    1,
 		},
 		wantCmds: []string{
-			`git "fetch" "origin" "refs/heads/master"`,
-			`git "fetch" "origin" "refs/pull/5/head:pull/5"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "origin" "refs/pull/5/head:pull/5"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "merge" "pull/5"`,
@@ -280,11 +284,12 @@ var testCases = [...]struct {
 			BranchDest:    "master",
 			PRID:          7,
 			ManualMerge:   false,
+			CloneDepth:    1,
 		},
 		patchSource: MockPatchSource{"diff_path", nil},
 		wantErr:     nil,
 		wantCmds: []string{
-			`git "fetch" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
 			`git "checkout" "--detach"`,
@@ -373,7 +378,7 @@ var testCases = [...]struct {
 			GivenRunWithRetrySucceeds(),
 		wantCmds: []string{
 			`git "fetch" "--depth=1" "origin" "refs/heads/master"`,
-			`git "fetch" "origin" "refs/pull/5/head:pull/5"`,
+			`git "fetch" "--depth=1" "origin" "refs/pull/5/head:pull/5"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "merge" "pull/5"`,

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -284,6 +284,7 @@ var testCases = [...]struct {
 			BranchDest:    "master",
 			PRID:          7,
 			ManualMerge:   false,
+			Commit:        "76a934ae", // TODO
 			CloneDepth:    1,
 		},
 		patchSource: MockPatchSource{"diff_path", nil},
@@ -293,6 +294,54 @@ var testCases = [...]struct {
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
 			`git "checkout" "--detach"`,
+		},
+	},
+	{
+		name: "PR - no fork - auto merge - diff file: fallback to manual merge if unable to apply patch",
+		cfg: Config{
+			RepositoryURL: "https://github.com/bitrise-io/git-clone-test.git",
+			Branch:        "test/commit-messages",
+			BranchDest:    "master",
+			PRID:          7,
+			ManualMerge:   false,
+			Commit:        "76a934ae", // TODO
+			CloneDepth:    1,
+		},
+		patchSource: MockPatchSource{"diff_path", nil},
+		mockRunner: givenMockRunner().
+			GivenRunFailsForCommand(`git "apply" "--index" "diff_path"`, 1).
+			GivenRunWithRetrySucceeds().
+			GivenRunSucceeds(),
+		wantCmds: []string{
+			`git "fetch" "--depth=1" "origin" "refs/heads/master"`,
+			`git "checkout" "master"`,
+			`git "apply" "--index" "diff_path"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/test/commit-messages"`,
+			`git "merge" "76a934ae"`,
+		},
+	},
+	{
+		name: "PR - fork - auto merge - diff file: fallback to manual merge if unable to apply patch",
+		cfg: Config{
+			RepositoryURL:   "https://github.com/bitrise-io/git-clone-test.git",
+			PRRepositoryURL: "git@github.com:bitrise-io/other-repo.git",
+			Branch:          "test/commit-messages",
+			BranchDest:      "master",
+			Commit:          "76a934ae", // TODO
+			ManualMerge:     true,
+		},
+		patchSource: MockPatchSource{"diff_path", nil},
+		mockRunner: givenMockRunner().
+			GivenRunFailsForCommand(`git "apply" "--index" "diff_path"`, 1).
+			GivenRunWithRetrySucceeds().
+			GivenRunSucceeds(),
+		wantCmds: []string{
+			`git "fetch" "origin" "refs/heads/master"`,
+			`git "checkout" "master"`,
+			`git "apply" "--index" "diff_path"`,
+			`git "remote" "add" "fork" "git@github.com:bitrise-io/other-repo.git"`,
+			`git "fetch" "fork" "refs/heads/test/commit-messages"`,
+			`git "merge" "fork/test/commit-messages"`,
 		},
 	},
 


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context
Previously there was a retry mechanism in place for applying a patch file for a certain branch, however, this behavior has been removed in _v4.0.0_. Based on user reports this resulted in an increased number of Step failures, so a revamped fallback logic is implemented.

If an error occurs during applying a patch file, the Step fallbacks to the _manual merge_ strategy.

Resolves: https://bitrise.atlassian.net/browse/STEP-200

### Changes
- `PRDiffFileParams` was extended by two new parameters:
  - `PRManualMergeParam` either holds a `PRManualMergeParams` object or `nil` (in case the PR has opened to the remote repository)
  - `ForkPRManualMergeParam` either holds a `ForkPRManualMergeParams` object or `nil` (in case the PR has opened on a forked repository)
- These new parameters are populated by the time the `CheckoutPRDiffFileMethod` was selected. This is done by the `createManualMergeParams` which instantiates the corresponding object, based on the result of the `isFork` method.
- Fallback logic is implemented by the `fallbackToManualMergeOnApplyError` method, which is executed upon an error has occurred during applying the patch file.
- Some reused parts (by the fallback method) were extracted in order to avoid code duplication.

### Investigation details

See the sub-tasks of [STEP-200](https://bitrise.atlassian.net/browse/STEP-200) for a detailed resolution.
