### PR TITLE
Merge manual merge strategies together

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,26 +39,26 @@ workflows:
     - activate-ssh-key:
         run_if: true
     after_run:
-    - _test_error
-    - _test_submodule
-    - _test_no_checkout
-    - _test_checkout_commit
-    - _test_checkout_commit_on_branch
-    - _test_checkout_tag
-    - _test_checkout_tag_with_other_branch
-    - _test_checkout_tag_with_equally_named_branch
-    - _test_checkout_branch
-    - _test_checkout_pull_request
-    - _test_checkout_pull_request_standard_branch
-    - _test_checkout_pull_request_with_depth
-    - _test_unshallow
-    - _test_checkout_different_dir
-    - _test_manual_merge_unshallow
-    - _test_commit_logs
-    - _test_hosted_git_notfork
-    - _test_unrelated_histories
-    - _test_hosted_git_ssh_prefix
-    - test_diff_file
+    # - _test_error
+    # - _test_submodule
+    # - _test_no_checkout
+    # - _test_checkout_commit
+    # - _test_checkout_commit_on_branch
+    # - _test_checkout_tag
+    # - _test_checkout_tag_with_other_branch
+    # - _test_checkout_tag_with_equally_named_branch
+    # - _test_checkout_branch
+    # - _test_checkout_pull_request
+    # - _test_checkout_pull_request_standard_branch
+    # - _test_checkout_pull_request_with_depth
+    # - _test_unshallow
+    # - _test_checkout_different_dir
+    # - _test_manual_merge_unshallow
+    # - _test_commit_logs
+    # - _test_hosted_git_notfork
+    # - _test_unrelated_histories
+    # - _test_hosted_git_ssh_prefix
+    # - test_diff_file
 
   go-tests:
     steps:
@@ -505,7 +505,7 @@ workflows:
         inputs:
         - dir_to_check: $CLONE_INTO_DIR
 
-  _test_hosted_git_ssh_prefix:
+  test_hosted_git_ssh_prefix:
     before_run:
     - _create_tmpdir
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -505,7 +505,7 @@ workflows:
         inputs:
         - dir_to_check: $CLONE_INTO_DIR
 
-  test_hosted_git_ssh_prefix:
+  _test_hosted_git_ssh_prefix:
     before_run:
     - _create_tmpdir
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,26 +39,26 @@ workflows:
     - activate-ssh-key:
         run_if: true
     after_run:
-    # - _test_error
-    # - _test_submodule
-    # - _test_no_checkout
-    # - _test_checkout_commit
-    # - _test_checkout_commit_on_branch
-    # - _test_checkout_tag
-    # - _test_checkout_tag_with_other_branch
-    # - _test_checkout_tag_with_equally_named_branch
-    # - _test_checkout_branch
-    # - _test_checkout_pull_request
-    # - _test_checkout_pull_request_standard_branch
-    # - _test_checkout_pull_request_with_depth
-    # - _test_unshallow
-    # - _test_checkout_different_dir
-    # - _test_manual_merge_unshallow
-    # - _test_commit_logs
-    # - _test_hosted_git_notfork
-    # - _test_unrelated_histories
-    # - _test_hosted_git_ssh_prefix
-    # - test_diff_file
+    - _test_error
+    - _test_submodule
+    - _test_no_checkout
+    - _test_checkout_commit
+    - _test_checkout_commit_on_branch
+    - _test_checkout_tag
+    - _test_checkout_tag_with_other_branch
+    - _test_checkout_tag_with_equally_named_branch
+    - _test_checkout_branch
+    - _test_checkout_pull_request
+    - _test_checkout_pull_request_standard_branch
+    - _test_checkout_pull_request_with_depth
+    - _test_unshallow
+    - _test_checkout_different_dir
+    - _test_manual_merge_unshallow
+    - _test_commit_logs
+    - _test_hosted_git_notfork
+    - _test_unrelated_histories
+    - _test_hosted_git_ssh_prefix
+    - test_diff_file
 
   go-tests:
     steps:
@@ -518,7 +518,7 @@ workflows:
         - pull_request_merge_branch:
         - pull_request_repository_url: "git@gitlab.com:bitrise/git-clone-test.git"
         - branch_dest: "master"
-        - commit: "842b0922232eeb09c1cf5c526f7cdd67ff0e83f7"
+        - commit: "8d558357cf085bc26af23b88f6bc4c07e175b8ac"
         - tag: ""
         - branch: "develop"
         - clone_depth: ""

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -219,12 +219,3 @@ func selectFallbacks(checkoutStrategy CheckoutMethod, fetchOpts fetchOptions) fa
 		return nil
 	}
 }
-
-// func createManualMergeParams(cfg Config) (prManualMergeParam *PRManualMergeParams, forkPRManualMergeParam *ForkPRManualMergeParams, err error) {
-// 	if isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
-// 		forkPRManualMergeParam, err = NewForkPRManualMergeParams(cfg.Branch, cfg.PRRepositoryURL, cfg.BranchDest)
-// 	} else {
-// 		prManualMergeParam, err = NewPRManualMergeParams(cfg.Branch, cfg.Commit, cfg.BranchDest)
-// 	}
-// 	return
-// }

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -169,8 +169,12 @@ func createCheckoutStrategy(checkoutMethod CheckoutMethod, cfg Config, patch pat
 		}
 	case CheckoutPRManualMergeMethod:
 		{
-			isFork := isFork(cfg.RepositoryURL, cfg.PRRepositoryURL)
-			params, err := NewPRManualMergeParams(isFork, cfg.Branch, cfg.Commit, cfg.PRRepositoryURL, cfg.BranchDest)
+			prRepositoryURL := ""
+			if isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
+				prRepositoryURL = cfg.PRRepositoryURL
+			}
+
+			params, err := NewPRManualMergeParams(cfg.Branch, cfg.Commit, prRepositoryURL, cfg.BranchDest)
 			if err != nil {
 				return nil, err
 			}

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -92,10 +92,6 @@ func selectCheckoutMethod(cfg Config) CheckoutMethod {
 		return CheckoutPRDiffFileMethod
 	}
 
-	if isFork {
-		return CheckoutForkPRManualMergeMethod
-	}
-
 	return CheckoutPRManualMergeMethod
 }
 
@@ -171,20 +167,10 @@ func createCheckoutStrategy(checkoutMethod CheckoutMethod, cfg Config, patch pat
 				patchFile: patchFile,
 			}, nil
 		}
-	case CheckoutForkPRManualMergeMethod:
-		{
-			params, err := NewForkPRManualMergeParams(cfg.Branch, cfg.PRRepositoryURL, cfg.BranchDest)
-			if err != nil {
-				return nil, err
-			}
-
-			return checkoutForkPRManualMerge{
-				params: *params,
-			}, nil
-		}
 	case CheckoutPRManualMergeMethod:
 		{
-			params, err := NewPRManualMergeParams(cfg.Branch, cfg.Commit, cfg.BranchDest)
+			isFork := isFork(cfg.RepositoryURL, cfg.PRRepositoryURL)
+			params, err := NewPRManualMergeParams(isFork, cfg.Branch, cfg.Commit, cfg.PRRepositoryURL, cfg.BranchDest)
 			if err != nil {
 				return nil, err
 			}

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -152,12 +152,12 @@ func createCheckoutStrategy(checkoutMethod CheckoutMethod, cfg Config, patch pat
 				return nil, fmt.Errorf("merging PR (automatic) failed, there is no Pull Request branch and could not download diff file: %v", err)
 			}
 
-			prManualMergeParam, forkPRManualMergeParam, err := createManualMergeParams(cfg)
+			prManualMergeParam, err := createCheckoutStrategy(CheckoutPRManualMergeMethod, cfg, patch)
 			if err != nil {
 				return nil, err
 			}
 
-			params, err := NewPRDiffFileParams(cfg.BranchDest, prManualMergeParam, forkPRManualMergeParam)
+			params, err := NewPRDiffFileParams(cfg.BranchDest, prManualMergeParam)
 			if err != nil {
 				return nil, err
 			}
@@ -220,11 +220,11 @@ func selectFallbacks(checkoutStrategy CheckoutMethod, fetchOpts fetchOptions) fa
 	}
 }
 
-func createManualMergeParams(cfg Config) (prManualMergeParam *PRManualMergeParams, forkPRManualMergeParam *ForkPRManualMergeParams, err error) {
-	if isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
- 		forkPRManualMergeParam, err = NewForkPRManualMergeParams(cfg.Branch, cfg.PRRepositoryURL, cfg.BranchDest)
- 	} else {
- 		prManualMergeParam, err = NewPRManualMergeParams(cfg.Branch, cfg.Commit, cfg.BranchDest)
- 	}
-	return
-}
+// func createManualMergeParams(cfg Config) (prManualMergeParam *PRManualMergeParams, forkPRManualMergeParam *ForkPRManualMergeParams, err error) {
+// 	if isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
+// 		forkPRManualMergeParam, err = NewForkPRManualMergeParams(cfg.Branch, cfg.PRRepositoryURL, cfg.BranchDest)
+// 	} else {
+// 		prManualMergeParam, err = NewPRManualMergeParams(cfg.Branch, cfg.Commit, cfg.BranchDest)
+// 	}
+// 	return
+// }

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -152,12 +152,12 @@ func createCheckoutStrategy(checkoutMethod CheckoutMethod, cfg Config, patch pat
 				return nil, fmt.Errorf("merging PR (automatic) failed, there is no Pull Request branch and could not download diff file: %v", err)
 			}
 
-			prManualMergeParam, err := createCheckoutStrategy(CheckoutPRManualMergeMethod, cfg, patch)
+			prManualMergeStrategy, err := createCheckoutStrategy(CheckoutPRManualMergeMethod, cfg, patch)
 			if err != nil {
 				return nil, err
 			}
 
-			params, err := NewPRDiffFileParams(cfg.BranchDest, prManualMergeParam)
+			params, err := NewPRDiffFileParams(cfg.BranchDest, prManualMergeStrategy)
 			if err != nil {
 				return nil, err
 			}

--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -134,15 +134,6 @@ func mergeWithCustomRetry(gitCmd git.Git, arg string, retry fallbackRetry) error
 	return nil
 }
 
-func fetchAndMerge(gitCmd git.Git, fetchParam fetchParams, mergeParam mergeParams) error {
-	headBranchRef := branchRefPrefix + fetchParam.branch
-	if err := fetch(gitCmd, fetchParam.remote, headBranchRef, fetchParam.options); err != nil {
-		return nil
-	}
-
-	return mergeWithCustomRetry(gitCmd, mergeParam.arg, mergeParam.fallback)
-}
-
 func detachHead(gitCmd git.Git) error {
 	if err := runner.Run(gitCmd.Checkout("--detach")); err != nil {
 		return newStepError(

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -52,7 +52,7 @@ func (c checkoutPRDiffFile) do(gitCmd git.Git, fetchOptions fetchOptions, fallba
 	}
 
 	if err := runner.Run(gitCmd.Apply(c.patchFile)); err != nil {
-		log.Warnf("Could not apply patch (%s)", c.patchFile)
+		log.Warnf("Could not apply patch (%s): %v", c.patchFile, err)
 		log.Warnf("Falling back to manual merge...")
 
 		if err := c.params.PRManualMergeStrategy.do(gitCmd, fetchOptions, fallback); err != nil {

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -52,7 +52,7 @@ func (c checkoutPRDiffFile) do(gitCmd git.Git, fetchOptions fetchOptions, fallba
 	}
 
 	if err := runner.Run(gitCmd.Apply(c.patchFile)); err != nil {
-		log.Warnf("Could not apply patch (%s): %v", c.patchFile, err)
+		log.Warnf("Could not apply patch (%s)", c.patchFile)
 		log.Warnf("Falling back to manual merge...")
 
 		if err := c.params.PRManualMergeStrategy.do(gitCmd, fetchOptions, fallback); err != nil {

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -23,7 +23,7 @@ type PRDiffFileParams struct {
 // NewPRDiffFileParams validates and returns a new PRDiffFileParams
 func NewPRDiffFileParams(
 	baseBranch string,
-	checkoutStrategy checkoutStrategy,
+	prManualMergeStrategy checkoutStrategy,
 ) (*PRDiffFileParams, error) {
 	if strings.TrimSpace(baseBranch) == "" {
 		return nil, NewParameterValidationError("PR diff file based checkout strategy can not be used: no base branch specified")
@@ -31,7 +31,7 @@ func NewPRDiffFileParams(
 
 	return &PRDiffFileParams{
 		BaseBranch:            baseBranch,
-		PRManualMergeStrategy: checkoutStrategy,
+		PRManualMergeStrategy: prManualMergeStrategy,
 	}, nil
 }
 

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -56,7 +56,7 @@ func (c checkoutPRDiffFile) do(gitCmd git.Git, fetchOptions fetchOptions, fallba
 		log.Warnf("Falling back to manual merge...")
 
 		if err := c.params.PRManualMergeStrategy.do(gitCmd, fetchOptions, fallback); err != nil {
-			return fmt.Errorf("Applying patch (%s) failed: %v", c.patchFile, err)
+			return fmt.Errorf("Fallback failed for applying patch (%s): %v", c.patchFile, err)
 		}
 
 		return nil

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -58,6 +58,8 @@ func (c checkoutPRDiffFile) do(gitCmd git.Git, fetchOptions fetchOptions, fallba
 		if err := c.params.PRManualMergeStrategy.do(gitCmd, fetchOptions, fallback); err != nil {
 			return fmt.Errorf("Applying patch (%s) failed: %v", c.patchFile, err)
 		}
+
+		return nil
 	}
 
 	return detachHead(gitCmd)

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -55,7 +55,9 @@ func (c checkoutPRDiffFile) do(gitCmd git.Git, fetchOptions fetchOptions, fallba
 		log.Warnf("Could not apply patch (%s): %v", c.patchFile, err)
 		log.Warnf("Falling back to manual merge...")
 
-		c.params.PRManualMergeStrategy.do(gitCmd, fetchOptions, fallback)
+		if err := c.params.PRManualMergeStrategy.do(gitCmd, fetchOptions, fallback); err != nil {
+			return fmt.Errorf("Applying patch (%s) failed: %v", c.patchFile, err)
+		}
 	}
 
 	return detachHead(gitCmd)

--- a/gitclone/checkout_method_pr_manual.go
+++ b/gitclone/checkout_method_pr_manual.go
@@ -36,15 +36,15 @@ func NewPRManualMergeParams(isFork bool, headBranch, commit, forkRepoURL, baseBr
 			HeadRepoURL: forkRepoURL,
 			BaseBranch:  baseBranch,
 		}, nil
-	} else {
-		return &PRManualMergeParams{
-			IsFork:      isFork,
-			HeadBranch:  headBranch,
-			MergeArg:    commit,
-			HeadRepoURL: "",
-			BaseBranch:  baseBranch,
-		}, nil
 	}
+
+	return &PRManualMergeParams{
+		IsFork:      isFork,
+		HeadBranch:  headBranch,
+		MergeArg:    commit,
+		HeadRepoURL: "",
+		BaseBranch:  baseBranch,
+	}, nil
 }
 
 func validatePRManualMergeParams(isFork bool, headBranch, commit, forkRepoURL, baseBranch string) error {

--- a/gitclone/checkout_method_pr_manual.go
+++ b/gitclone/checkout_method_pr_manual.go
@@ -27,24 +27,21 @@ func NewPRManualMergeParams(isFork bool, headBranch, commit, forkRepoURL, baseBr
 		return nil, err
 	}
 
-	if isFork {
-		remoteForkBranch := fmt.Sprintf("%s/%s", forkRemoteName, headBranch)
-		return &PRManualMergeParams{
-			IsFork:      isFork,
-			HeadBranch:  headBranch,
-			MergeArg:    remoteForkBranch,
-			HeadRepoURL: forkRepoURL,
-			BaseBranch:  baseBranch,
-		}, nil
+	prManualMergeParams := &PRManualMergeParams{
+		IsFork:     isFork,
+		HeadBranch: headBranch,
+		BaseBranch: baseBranch,
 	}
 
-	return &PRManualMergeParams{
-		IsFork:      isFork,
-		HeadBranch:  headBranch,
-		MergeArg:    commit,
-		HeadRepoURL: "",
-		BaseBranch:  baseBranch,
-	}, nil
+	if isFork {
+		prManualMergeParams.MergeArg = fmt.Sprintf("%s/%s", forkRemoteName, headBranch)
+		prManualMergeParams.HeadRepoURL = forkRepoURL
+	} else {
+		prManualMergeParams.MergeArg = commit
+		prManualMergeParams.HeadRepoURL = ""
+	}
+
+	return prManualMergeParams, nil
 }
 
 func validatePRManualMergeParams(isFork bool, headBranch, commit, forkRepoURL, baseBranch string) error {

--- a/gitclone/checkout_method_pr_manual.go
+++ b/gitclone/checkout_method_pr_manual.go
@@ -8,6 +8,8 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 )
 
+const forkRemoteName = "fork"
+
 // PRManualMergeParams are parameters to check out a Merge Request using manual merge
 type PRManualMergeParams struct {
 	IsFork bool
@@ -66,7 +68,6 @@ func validatePRManualMergeParams(isFork bool, headBranch, commit, forkRepoURL, b
 	return nil
 }
 
-// checkoutPRManualMerge
 type checkoutPRManualMerge struct {
 	params PRManualMergeParams
 }
@@ -86,7 +87,6 @@ func (c checkoutPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fal
 
 	remoteName := originRemoteName
 	if c.params.IsFork {
-		const forkRemoteName = "fork"
 		// Add fork remote
 		if err := runner.Run(gitCmd.RemoteAdd(forkRemoteName, c.params.HeadRepoURL)); err != nil {
 			return fmt.Errorf("adding remote fork repository failed (%s): %v", c.params.HeadRepoURL, err)

--- a/gitclone/checkout_method_pr_manual.go
+++ b/gitclone/checkout_method_pr_manual.go
@@ -85,14 +85,17 @@ func (c checkoutPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fal
 	}
 	log.Printf("commit hash: %s", commitHash)
 
-	remoteName := originRemoteName
+	var remoteName string
 	if c.params.IsFork {
+		remoteName = forkRemoteName
+
 		// Add fork remote
 		if err := runner.Run(gitCmd.RemoteAdd(forkRemoteName, c.params.HeadRepoURL)); err != nil {
 			return fmt.Errorf("adding remote fork repository failed (%s): %v", c.params.HeadRepoURL, err)
 		}
 
-		remoteName = forkRemoteName
+	} else {
+		remoteName = originRemoteName
 	}
 
 	// Fetch and merge

--- a/gitclone/checkout_method_pr_manual.go
+++ b/gitclone/checkout_method_pr_manual.go
@@ -8,32 +8,62 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 )
 
-//
 // PRManualMergeParams are parameters to check out a Merge Request using manual merge
 type PRManualMergeParams struct {
+	IsFork bool
 	// Source
-	HeadBranch, Commit string
+	HeadBranch  string
+	MergeArg    string
+	HeadRepoURL string // Optional
 	// Target
 	BaseBranch string
 }
 
 //NewPRManualMergeParams validates and returns a new PRManualMergeParams
-func NewPRManualMergeParams(headBranch, commit, baseBranch string) (*PRManualMergeParams, error) {
-	if strings.TrimSpace(headBranch) == "" {
-		return nil, NewParameterValidationError("manual PR merge checkout strategy can not be used: no head branch specified")
-	}
-	if strings.TrimSpace(commit) == "" {
-		return nil, NewParameterValidationError("manual PR merge checkout strategy can not be used: no head branch commit hash specified")
-	}
-	if strings.TrimSpace(baseBranch) == "" {
-		return nil, NewParameterValidationError("manual PR merge checkout strategy can not be used: no base branch specified")
+func NewPRManualMergeParams(isFork bool, headBranch, commit, forkRepoURL, baseBranch string) (*PRManualMergeParams, error) {
+	if err := validatePRManualMergeParams(isFork, headBranch, commit, forkRepoURL, baseBranch); err != nil {
+		return nil, err
 	}
 
-	return &PRManualMergeParams{
-		HeadBranch: headBranch,
-		Commit:     commit,
-		BaseBranch: baseBranch,
-	}, nil
+	if isFork {
+		remoteForkBranch := fmt.Sprintf("%s/%s", forkRemoteName, headBranch)
+		return &PRManualMergeParams{
+			IsFork:      isFork,
+			HeadBranch:  headBranch,
+			MergeArg:    remoteForkBranch,
+			HeadRepoURL: forkRepoURL,
+			BaseBranch:  baseBranch,
+		}, nil
+	} else {
+		return &PRManualMergeParams{
+			IsFork:      isFork,
+			HeadBranch:  headBranch,
+			MergeArg:    commit,
+			HeadRepoURL: "",
+			BaseBranch:  baseBranch,
+		}, nil
+	}
+}
+
+func validatePRManualMergeParams(isFork bool, headBranch, commit, forkRepoURL, baseBranch string) error {
+	if strings.TrimSpace(headBranch) == "" {
+		return NewParameterValidationError("manual PR merge checkout strategy can not be used: no head branch specified")
+	}
+	if strings.TrimSpace(baseBranch) == "" {
+		return NewParameterValidationError("manual PR merge checkout strategy can not be used: no base branch specified")
+	}
+
+	if isFork {
+		if strings.TrimSpace(forkRepoURL) == "" {
+			return NewParameterValidationError("manual PR merge chekout strategy can not be used: no base repository URL specified")
+		}
+	} else {
+		if strings.TrimSpace(commit) == "" {
+			return NewParameterValidationError("manual PR merge checkout strategy can not be used: no head branch commit hash specified")
+		}
+	}
+
+	return nil
 }
 
 // checkoutPRManualMerge
@@ -54,79 +84,24 @@ func (c checkoutPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fal
 	}
 	log.Printf("commit hash: %s", commitHash)
 
+	remoteName := originRemoteName
+	if c.params.IsFork {
+		const forkRemoteName = "fork"
+		// Add fork remote
+		if err := runner.Run(gitCmd.RemoteAdd(forkRemoteName, c.params.HeadRepoURL)); err != nil {
+			return fmt.Errorf("adding remote fork repository failed (%s): %v", c.params.HeadRepoURL, err)
+		}
+
+		remoteName = forkRemoteName
+	}
+
 	// Fetch and merge
-	headBranchRef := branchRefPrefix + c.params.HeadBranch
-	if err := fetch(gitCmd, originRemoteName, headBranchRef, fetchOptions); err != nil {
+	branchRef := branchRefPrefix + c.params.HeadBranch
+	if err := fetch(gitCmd, remoteName, branchRef, fetchOptions); err != nil {
 		return nil
 	}
 
-	if err := mergeWithCustomRetry(gitCmd, c.params.Commit, fallback); err != nil {
-		return err
-	}
-
-	return detachHead(gitCmd)
-}
-
-//
-// ForkPRManualMergeParams are parameters to check out a Pull Request using manual merge
-type ForkPRManualMergeParams struct {
-	// Source
-	HeadBranch, HeadRepoURL string
-	// Target
-	BaseBranch string
-}
-
-// NewForkPRManualMergeParams validates and returns a new ForkPRManualMergeParams
-func NewForkPRManualMergeParams(headBranch, forkRepoURL, baseBranch string) (*ForkPRManualMergeParams, error) {
-	if strings.TrimSpace(headBranch) == "" {
-		return nil, NewParameterValidationError("manual PR (fork) merge checkout strategy can not be used: no head branch specified")
-	}
-	if strings.TrimSpace(forkRepoURL) == "" {
-		return nil, NewParameterValidationError("manual PR (fork) merge chekout strategy can not be used: no base repository URL specified")
-	}
-	if strings.TrimSpace(baseBranch) == "" {
-		return nil, NewParameterValidationError("manual PR (fork) merge checkout strategy can not be used: no base branch specified")
-	}
-
-	return &ForkPRManualMergeParams{
-		HeadBranch:  headBranch,
-		HeadRepoURL: forkRepoURL,
-		BaseBranch:  baseBranch,
-	}, nil
-}
-
-// checkoutForkPRManualMerge
-type checkoutForkPRManualMerge struct {
-	params ForkPRManualMergeParams
-}
-
-func (c checkoutForkPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
-	// Fetch and checkout base branch
-	baseBranchRef := branchRefPrefix + c.params.BaseBranch
-	if err := fetchInitialBranch(gitCmd, originRemoteName, baseBranchRef, fetchOptions); err != nil {
-		return err
-	}
-
-	commitHash, err := runner.RunForOutput(gitCmd.Log("%H"))
-	if err != nil {
-		log.Errorf("log commit hash: %v", err)
-	}
-	log.Printf("commit hash: %s", commitHash)
-
-	const forkRemoteName = "fork"
-	// Add fork remote
-	if err := runner.Run(gitCmd.RemoteAdd(forkRemoteName, c.params.HeadRepoURL)); err != nil {
-		return fmt.Errorf("adding remote fork repository failed (%s): %v", c.params.HeadRepoURL, err)
-	}
-
-	// Fetch + merge fork branch
-	forkBranchRef := branchRefPrefix + c.params.HeadBranch
-	if err := fetch(gitCmd, forkRemoteName, forkBranchRef, fetchOptions); err != nil {
-		return err
-	}
-
-	remoteForkBranch := fmt.Sprintf("%s/%s", forkRemoteName, c.params.HeadBranch)
-	if err := mergeWithCustomRetry(gitCmd, remoteForkBranch, fallback); err != nil {
+	if err := mergeWithCustomRetry(gitCmd, c.params.MergeArg, fallback); err != nil {
 		return err
 	}
 

--- a/gitclone/checkout_test.go
+++ b/gitclone/checkout_test.go
@@ -101,7 +101,7 @@ func Test_selectCheckoutMethod(t *testing.T) {
 				Commit:          "76a934ae",
 				ManualMerge:     true,
 			},
-			want: CheckoutForkPRManualMergeMethod,
+			want: CheckoutPRManualMergeMethod,
 		},
 		{
 			name: "PR - no fork - manual merge: repo is the same with different scheme",

--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -32,9 +32,8 @@ type Config struct {
 
 const (
 	trimEnding              = "..."
-	originRemoteName       = "origin"
+	originRemoteName        = "origin"
 	updateSubmodelFailedTag = "update_submodule_failed"
-	forkRemoteName = "fork"
 )
 
 func printLogAndExportEnv(gitCmd git.Git, format, env string, maxEnvLength int) error {

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -322,8 +322,7 @@ var testCases = [...]struct {
 			`git "log" "-1" "--format=%H"`,
 			`git "fetch" "--depth=1" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
-			`git "checkout" "--detach"`, // Detach for manual merge
-			`git "checkout" "--detach"`, // Detach for auto merge
+			`git "checkout" "--detach"`,
 		},
 	},
 	{
@@ -352,8 +351,7 @@ var testCases = [...]struct {
 			`git "remote" "add" "fork" "git@github.com:bitrise-io/other-repo.git"`,
 			`git "fetch" "fork" "refs/heads/test/commit-messages"`,
 			`git "merge" "fork/test/commit-messages"`,
-			`git "checkout" "--detach"`, // Detach for manual merge
-			`git "checkout" "--detach"`, // Detach for auto merge
+			`git "checkout" "--detach"`,
 		},
 	},
 

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -316,8 +316,14 @@ var testCases = [...]struct {
 			`git "fetch" "--depth=1" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/master"`,
+			`git "checkout" "master"`,
+			`git "merge" "origin/master"`,
+			`git "log" "-1" "--format=%H"`,
 			`git "fetch" "--depth=1" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
+			`git "checkout" "--detach"`, // Detach for manual merge
+			`git "checkout" "--detach"`, // Detach for auto merge
 		},
 	},
 	{
@@ -339,9 +345,15 @@ var testCases = [...]struct {
 			`git "fetch" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
+			`git "fetch" "origin" "refs/heads/master"`,
+			`git "checkout" "master"`,
+			`git "merge" "origin/master"`,
+			`git "log" "-1" "--format=%H"`,
 			`git "remote" "add" "fork" "git@github.com:bitrise-io/other-repo.git"`,
 			`git "fetch" "fork" "refs/heads/test/commit-messages"`,
 			`git "merge" "fork/test/commit-messages"`,
+			`git "checkout" "--detach"`, // Detach for manual merge
+			`git "checkout" "--detach"`, // Detach for auto merge
 		},
 	},
 

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -189,14 +189,13 @@ var testCases = [...]struct {
 	{
 		name: "PR - no fork - manual merge: repo is the same with different scheme",
 		cfg: Config{
-			RepositoryURL:   "https://github.com/bitrise-io/git-clone-test.git",
-			PRRepositoryURL: "git@github.com:bitrise-io/git-clone-test.git",
-			Branch:          "test/commit-messages",
-			BranchDest:      "master",
-			PRMergeBranch:   "pull/7/merge",
-			PRID:            7,
-			Commit:          "76a934ae",
-			ManualMerge:     true,
+			RepositoryURL: "https://github.com/bitrise-io/git-clone-test.git",
+			Branch:        "test/commit-messages",
+			BranchDest:    "master",
+			PRMergeBranch: "pull/7/merge",
+			PRID:          7,
+			Commit:        "76a934ae",
+			ManualMerge:   true,
 		},
 		wantCmds: []string{
 			`git "fetch" "origin" "refs/heads/master"`,

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -189,13 +189,14 @@ var testCases = [...]struct {
 	{
 		name: "PR - no fork - manual merge: repo is the same with different scheme",
 		cfg: Config{
-			RepositoryURL: "https://github.com/bitrise-io/git-clone-test.git",
-			Branch:        "test/commit-messages",
-			BranchDest:    "master",
-			PRMergeBranch: "pull/7/merge",
-			PRID:          7,
-			Commit:        "76a934ae",
-			ManualMerge:   true,
+			RepositoryURL:   "https://github.com/bitrise-io/git-clone-test.git",
+			PRRepositoryURL: "git@github.com:bitrise-io/git-clone-test.git",
+			Branch:          "test/commit-messages",
+			BranchDest:      "master",
+			PRMergeBranch:   "pull/7/merge",
+			PRID:            7,
+			Commit:          "76a934ae",
+			ManualMerge:     true,
 		},
 		wantCmds: []string{
 			`git "fetch" "origin" "refs/heads/master"`,


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/STEP-688

### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context
The previous intention that we should merge the two (regular and fork) manual merge strategies together was strengthened by [this](https://github.com/bitrise-steplib/steps-git-clone/pull/139) PR, since a huge amount of code duplication and simplification can be done by this change.

### Changes
- Standalone `CheckoutForkPRManualMergeMethod` checkout strategy removed.
- The `CheckoutPRManualMergeMethod` checkout strategy was extended by the parameters of the fork method, also with an attribute indicating whether the repository is a fork or not.
- The two (regular and fork) actions merged together into the same `do` method, toggled the `isFork` attribute, which is needed to execute.
- Auto-merge strategy updated to contain and use the unified manual merge as a fallback.
- Some unused helper methods removed.
- Tests updated.

### Investigation details
There was no need for further investigation.
