### PR TITLE
Adding new input to make PR merge optional

### DIFF
--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -40,7 +40,7 @@ func (e ParameterValidationError) Error() string {
 	return e.ErrorString
 }
 
-// NewParameterValidationError return a new ValidationError
+// NewParameterValidationError returns a new ValidationError
 func NewParameterValidationError(msg string) error {
 	return ParameterValidationError{ErrorString: msg}
 }
@@ -236,9 +236,9 @@ func selectFallbacks(checkoutStrategy CheckoutMethod, fetchOpts fetchOptions) fa
 
 func createManualMergeParams(cfg Config) (prManualMergeParam *PRManualMergeParams, forkPRManualMergeParam *ForkPRManualMergeParams, err error) {
 	if isFork(cfg.RepositoryURL, cfg.PRRepositoryURL) {
- 		forkPRManualMergeParam, err = NewForkPRManualMergeParams(cfg.Branch, cfg.PRRepositoryURL, cfg.BranchDest)
- 	} else {
- 		prManualMergeParam, err = NewPRManualMergeParams(cfg.Branch, cfg.Commit, cfg.BranchDest)
- 	}
+		forkPRManualMergeParam, err = NewForkPRManualMergeParams(cfg.Branch, cfg.PRRepositoryURL, cfg.BranchDest)
+	} else {
+		prManualMergeParam, err = NewPRManualMergeParams(cfg.Branch, cfg.Commit, cfg.BranchDest)
+	}
 	return
 }

--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -112,16 +112,6 @@ func fetchInitialBranch(gitCmd git.Git, remote string, branchRef string, fetchTr
 		)
 	}
 
-	// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.
-	remoteBranch := fmt.Sprintf("%s/%s", originRemoteName, trackingBranch)
-	if err := runner.Run(gitCmd.Merge(remoteBranch)); err != nil {
-		return newStepError(
-			"update_branch_failed",
-			fmt.Errorf("updating branch (merge) failed %s: %v", trackingBranch, err),
-			"Updating branch failed",
-		)
-	}
-
 	return nil
 }
 

--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -41,6 +41,17 @@ const (
 	refsPrefix      = "refs/"
 )
 
+func branchRefToTrackingBranch(branchRef string) string {
+	trackingBranch := branchRef
+	if strings.HasPrefix(branchRef, refsHeadsPrefix) {
+		trackingBranch = strings.TrimPrefix(trackingBranch, refsHeadsPrefix)
+	} else {
+		trackingBranch = strings.TrimPrefix(trackingBranch, refsPrefix)
+	}
+
+	return trackingBranch
+}
+
 func fetch(gitCmd git.Git, remote string, ref string, trackingBranch string, traits fetchOptions) error {
 	var opts []string
 	if traits.depth != 0 {
@@ -96,8 +107,7 @@ func checkoutWithCustomRetry(gitCmd git.Git, arg string, retry fallbackRetry) er
 }
 
 func fetchInitialBranch(gitCmd git.Git, remote string, branchRef string, fetchTraits fetchOptions) error {
-	trackingBranch := strings.TrimPrefix(branchRef, refsHeadsPrefix)
-	trackingBranch = strings.TrimPrefix(trackingBranch, refsPrefix)
+	trackingBranch := branchRefToTrackingBranch(branchRef)
 	if err := fetch(gitCmd, remote, branchRef, trackingBranch, fetchTraits); err != nil {
 		return err
 	}

--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -36,7 +36,10 @@ func (t fetchOptions) IsFullDepth() bool {
 	return t.depth == 0
 }
 
-const branchRefPrefix = "refs/heads/"
+const (
+	refsHeadsPrefix = "refs/heads/"
+	refsPrefix      = "refs/"
+)
 
 func fetch(gitCmd git.Git, remote string, ref string, traits fetchOptions) error {
 	var opts []string
@@ -52,8 +55,8 @@ func fetch(gitCmd git.Git, remote string, ref string, traits fetchOptions) error
 
 	// Not neccessarily a branch, can be tag too
 	branch := ""
-	if strings.HasPrefix(ref, branchRefPrefix) {
-		branch = strings.TrimPrefix(ref, branchRefPrefix)
+	if strings.HasPrefix(ref, refsHeadsPrefix) {
+		branch = strings.TrimPrefix(ref, refsHeadsPrefix)
 	}
 
 	if err := runner.RunWithRetry(func() *command.Model {
@@ -89,7 +92,7 @@ func checkoutWithCustomRetry(gitCmd git.Git, arg string, retry fallbackRetry) er
 }
 
 func fetchInitialBranch(gitCmd git.Git, remote string, branchRef string, fetchTraits fetchOptions) error {
-	branch := strings.TrimPrefix(branchRef, branchRefPrefix)
+	branch := strings.TrimPrefix(branchRef, refsPrefix)
 	if err := fetch(gitCmd, remote, branchRef, fetchTraits); err != nil {
 		return err
 	}
@@ -135,7 +138,7 @@ func mergeWithCustomRetry(gitCmd git.Git, arg string, retry fallbackRetry) error
 }
 
 func fetchAndMerge(gitCmd git.Git, fetchParam fetchParams, mergeParam mergeParams) error {
-	headBranchRef := branchRefPrefix + fetchParam.branch
+	headBranchRef := refsHeadsPrefix + fetchParam.branch
 	if err := fetch(gitCmd, fetchParam.remote, headBranchRef, fetchParam.options); err != nil {
 		return nil
 	}

--- a/gitclone/checkout_helper_test.go
+++ b/gitclone/checkout_helper_test.go
@@ -1,0 +1,34 @@
+package gitclone
+
+import "testing"
+
+func Test_branchRefToTrackingBranch(t *testing.T) {
+	tests := []struct {
+		name      string
+		branchRef string
+		want      string
+	}{
+		{
+			"Branch refspec",
+			"refs/heads/master",
+			"master",
+		},
+		{
+			"Branch with refs in name",
+			"refs/heads/refs/master",
+			"refs/master",
+		},
+		{
+			"Head/merge branch refspec",
+			"refs/pull/1/head",
+			"pull/1/head",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := branchRefToTrackingBranch(tt.branchRef); got != tt.want {
+				t.Errorf("branchRefToTrackingBranch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -45,7 +45,7 @@ type checkoutPRDiffFile struct {
 }
 
 func (c checkoutPRDiffFile) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
-	baseBranchRef := branchRefPrefix + c.params.BaseBranch
+	baseBranchRef := refsHeadsPrefix + c.params.BaseBranch
 	if err := fetch(gitCmd, originRemoteName, baseBranchRef, fetchOptions); err != nil {
 		return err
 	}

--- a/gitclone/checkout_method_pr_auto_diff.go
+++ b/gitclone/checkout_method_pr_auto_diff.go
@@ -46,7 +46,7 @@ type checkoutPRDiffFile struct {
 
 func (c checkoutPRDiffFile) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
 	baseBranchRef := refsHeadsPrefix + c.params.BaseBranch
-	if err := fetch(gitCmd, originRemoteName, baseBranchRef, fetchOptions); err != nil {
+	if err := fetch(gitCmd, originRemoteName, baseBranchRef, "", fetchOptions); err != nil {
 		return err
 	}
 

--- a/gitclone/checkout_method_pr_auto_merge_branch.go
+++ b/gitclone/checkout_method_pr_auto_merge_branch.go
@@ -37,7 +37,7 @@ type checkoutPRMergeBranch struct {
 func (c checkoutPRMergeBranch) do(gitCmd git.Git, fetchOpts fetchOptions, fallback fallbackRetry) error {
 	// Check out initial branch (fetchInitialBranch part1)
 	// `git "fetch" "origin" "refs/heads/master"`
-	baseBranchRef := branchRefPrefix + c.params.BaseBranch
+	baseBranchRef := refsHeadsPrefix + c.params.BaseBranch
 	if err := fetch(gitCmd, originRemoteName, baseBranchRef, fetchOpts); err != nil {
 		return err
 	}

--- a/gitclone/checkout_method_pr_auto_merge_branch.go
+++ b/gitclone/checkout_method_pr_auto_merge_branch.go
@@ -38,13 +38,13 @@ func (c checkoutPRMergeBranch) do(gitCmd git.Git, fetchOpts fetchOptions, fallba
 	// Check out initial branch (fetchInitialBranch part1)
 	// `git "fetch" "origin" "refs/heads/master"`
 	baseBranchRef := refsHeadsPrefix + c.params.BaseBranch
-	if err := fetch(gitCmd, originRemoteName, baseBranchRef, fetchOpts); err != nil {
+	if err := fetch(gitCmd, originRemoteName, baseBranchRef, "", fetchOpts); err != nil {
 		return err
 	}
 
 	// `git "fetch" "origin" "refs/pull/7/head:pull/7"`
 	headBranchRef := fetchArg(c.params.MergeBranch)
-	if err := fetch(gitCmd, originRemoteName, headBranchRef, fetchOpts); err != nil {
+	if err := fetch(gitCmd, originRemoteName, headBranchRef, "", fetchOpts); err != nil {
 		return err
 	}
 

--- a/gitclone/checkout_method_pr_manual.go
+++ b/gitclone/checkout_method_pr_manual.go
@@ -56,7 +56,7 @@ func (c checkoutPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fal
 
 	// Fetch and merge
 	headBranchRef := refsHeadsPrefix + c.params.HeadBranch
-	if err := fetch(gitCmd, originRemoteName, headBranchRef, fetchOptions); err != nil {
+	if err := fetch(gitCmd, originRemoteName, headBranchRef, "", fetchOptions); err != nil {
 		return nil
 	}
 
@@ -121,7 +121,7 @@ func (c checkoutForkPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions,
 
 	// Fetch + merge fork branch
 	forkBranchRef := refsHeadsPrefix + c.params.HeadBranch
-	if err := fetch(gitCmd, forkRemoteName, forkBranchRef, fetchOptions); err != nil {
+	if err := fetch(gitCmd, forkRemoteName, forkBranchRef, "", fetchOptions); err != nil {
 		return err
 	}
 

--- a/gitclone/checkout_method_pr_manual.go
+++ b/gitclone/checkout_method_pr_manual.go
@@ -43,7 +43,7 @@ type checkoutPRManualMerge struct {
 
 func (c checkoutPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
 	// Fetch and checkout base (target) branch
-	baseBranchRef := branchRefPrefix + c.params.BaseBranch
+	baseBranchRef := refsHeadsPrefix + c.params.BaseBranch
 	if err := fetchInitialBranch(gitCmd, originRemoteName, baseBranchRef, fetchOptions); err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (c checkoutPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fal
 	log.Printf("commit hash: %s", commitHash)
 
 	// Fetch and merge
-	headBranchRef := branchRefPrefix + c.params.HeadBranch
+	headBranchRef := refsHeadsPrefix + c.params.HeadBranch
 	if err := fetch(gitCmd, originRemoteName, headBranchRef, fetchOptions); err != nil {
 		return nil
 	}
@@ -102,7 +102,7 @@ type checkoutForkPRManualMerge struct {
 
 func (c checkoutForkPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
 	// Fetch and checkout base branch
-	baseBranchRef := branchRefPrefix + c.params.BaseBranch
+	baseBranchRef := refsHeadsPrefix + c.params.BaseBranch
 	if err := fetchInitialBranch(gitCmd, originRemoteName, baseBranchRef, fetchOptions); err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (c checkoutForkPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions,
 	}
 
 	// Fetch + merge fork branch
-	forkBranchRef := branchRefPrefix + c.params.HeadBranch
+	forkBranchRef := refsHeadsPrefix + c.params.HeadBranch
 	if err := fetch(gitCmd, forkRemoteName, forkBranchRef, fetchOptions); err != nil {
 		return err
 	}

--- a/gitclone/checkout_method_simple.go
+++ b/gitclone/checkout_method_simple.go
@@ -44,7 +44,7 @@ func (c checkoutCommit) do(gitCmd git.Git, fetchOptions fetchOptions, fallback f
 		branchRefParam = refsHeadsPrefix + c.params.Branch
 	}
 
-	if err := fetch(gitCmd, originRemoteName, branchRefParam, fetchOptions); err != nil {
+	if err := fetch(gitCmd, originRemoteName, branchRefParam, "", fetchOptions); err != nil {
 		return err
 	}
 
@@ -115,7 +115,7 @@ func (c checkoutTag) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fall
 		branchRefParam = refsHeadsPrefix + c.params.Branch
 	}
 
-	if err := fetch(gitCmd, originRemoteName, branchRefParam, fetchOptions); err != nil {
+	if err := fetch(gitCmd, originRemoteName, branchRefParam, "", fetchOptions); err != nil {
 		return err
 	}
 

--- a/gitclone/checkout_method_simple.go
+++ b/gitclone/checkout_method_simple.go
@@ -41,7 +41,7 @@ type checkoutCommit struct {
 func (c checkoutCommit) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
 	branchRefParam := ""
 	if c.params.Branch != "" {
-		branchRefParam = branchRefPrefix + c.params.Branch
+		branchRefParam = refsHeadsPrefix + c.params.Branch
 	}
 
 	if err := fetch(gitCmd, originRemoteName, branchRefParam, fetchOptions); err != nil {
@@ -58,17 +58,17 @@ func (c checkoutCommit) do(gitCmd git.Git, fetchOptions fetchOptions, fallback f
 //
 // BranchParams are parameters to check out a given branch (In addition to the repository URL)
 type BranchParams struct {
-	Branch string
+	BranchRef string
 }
 
 // NewBranchParams validates and returns a new BranchParams
-func NewBranchParams(branch string) (*BranchParams, error) {
-	if strings.TrimSpace(branch) == "" {
+func NewBranchParams(branchRef string) (*BranchParams, error) {
+	if strings.TrimSpace(branchRef) == "" {
 		return nil, NewParameterValidationError("branch checkout strategy can not be used: no branch specified")
 	}
 
 	return &BranchParams{
-		Branch: branch,
+		BranchRef: branchRef,
 	}, nil
 }
 
@@ -78,8 +78,7 @@ type checkoutBranch struct {
 }
 
 func (c checkoutBranch) do(gitCmd git.Git, fetchOptions fetchOptions, _ fallbackRetry) error {
-	branchRef := branchRefPrefix + c.params.Branch
-	if err := fetchInitialBranch(gitCmd, originRemoteName, branchRef, fetchOptions); err != nil {
+	if err := fetchInitialBranch(gitCmd, originRemoteName, c.params.BranchRef, fetchOptions); err != nil {
 		return err
 	}
 
@@ -113,7 +112,7 @@ type checkoutTag struct {
 func (c checkoutTag) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
 	branchRefParam := ""
 	if c.params.Branch != "" {
-		branchRefParam = branchRefPrefix + c.params.Branch
+		branchRefParam = refsHeadsPrefix + c.params.Branch
 	}
 
 	if err := fetch(gitCmd, originRemoteName, branchRefParam, fetchOptions); err != nil {

--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -21,6 +21,7 @@ type Config struct {
 	PRID            int    `env:"pull_request_id"`
 	PRRepositoryURL string `env:"pull_request_repository_url"`
 	PRMergeBranch   string `env:"pull_request_merge_branch"`
+	PRHeadBranch    string `env:"pull_request_head_branch"`
 	// Clone options
 	UpdateSubmodules bool `env:"update_submodules,opt[yes,no]"`
 	CloneDepth       int  `env:"clone_depth"`

--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -21,20 +21,22 @@ type Config struct {
 	PRID            int    `env:"pull_request_id"`
 	PRRepositoryURL string `env:"pull_request_repository_url"`
 	PRMergeBranch   string `env:"pull_request_merge_branch"`
+	// Clone options
+	UpdateSubmodules bool `env:"update_submodules,opt[yes,no]"`
+	CloneDepth       int  `env:"clone_depth"`
+	ShouldMergePR    bool `env:"merge_pr,opt[yes,no]"`
+	// Debug options
 	ResetRepository bool   `env:"reset_repository,opt[Yes,No]"`
-	CloneDepth      int    `env:"clone_depth"`
-
-	BuildURL         string `env:"build_url"`
-	BuildAPIToken    string `env:"build_api_token"`
-	UpdateSubmodules bool   `env:"update_submodules,opt[yes,no]"`
-	ManualMerge      bool   `env:"manual_merge,opt[yes,no]"`
+	ManualMerge     bool   `env:"manual_merge,opt[yes,no]"`
+	BuildURL        string `env:"build_url"`
+	BuildAPIToken   string `env:"build_api_token"`
 }
 
 const (
 	trimEnding              = "..."
-	originRemoteName       = "origin"
+	originRemoteName        = "origin"
 	updateSubmodelFailedTag = "update_submodule_failed"
-	forkRemoteName = "fork"
+	forkRemoteName          = "fork"
 )
 
 func printLogAndExportEnv(gitCmd git.Git, format, env string, maxEnvLength int) error {

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -67,9 +67,8 @@ var testCases = [...]struct {
 			CloneDepth: 1,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "origin" "refs/heads/hcnarb"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/hcnarb:hcnarb"`,
 			`git "checkout" "hcnarb"`,
-			`git "merge" "origin/hcnarb"`,
 		},
 	},
 	{
@@ -142,9 +141,8 @@ var testCases = [...]struct {
 			ManualMerge:   true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "origin" "refs/heads/master"`,
-			`git "checkout" "master"`,     // Already on 'master'
-			`git "merge" "origin/master"`, // Already up to date.
+			`git "fetch" "--depth=1" "origin" "refs/heads/master:master"`,
+			`git "checkout" "master"`, // Already on 'master'
 			`git "log" "-1" "--format=%H"`,
 			`git "fetch" "--depth=1" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
@@ -176,9 +174,8 @@ var testCases = [...]struct {
 			CloneDepth:      1,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/master:master"`,
 			`git "checkout" "master"`,
-			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
 			`git "remote" "add" "fork" "https://github.com/bitrise-io/other-repo.git"`,
 			`git "fetch" "--depth=1" "fork" "refs/heads/test/commit-messages"`,
@@ -199,9 +196,8 @@ var testCases = [...]struct {
 			ManualMerge:     true,
 		},
 		wantCmds: []string{
-			`git "fetch" "origin" "refs/heads/master"`,
+			`git "fetch" "origin" "refs/heads/master:master"`,
 			`git "checkout" "master"`,
-			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
 			`git "fetch" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
@@ -355,9 +351,9 @@ var testCases = [...]struct {
 			GivenRunWithRetryFailsAfter(2).
 			GivenRunSucceeds(),
 		wantCmds: []string{
-			`git "fetch" "origin" "refs/heads/fake"`,
-			`git "fetch" "origin" "refs/heads/fake"`,
-			`git "fetch" "origin" "refs/heads/fake"`,
+			`git "fetch" "origin" "refs/heads/fake:fake"`,
+			`git "fetch" "origin" "refs/heads/fake:fake"`,
+			`git "fetch" "origin" "refs/heads/fake:fake"`,
 			`git "fetch"`,
 			`git "branch" "-r"`,
 		},

--- a/step.yml
+++ b/step.yml
@@ -87,6 +87,14 @@ inputs:
       category: "Clone arguments"
       title: "Merged pull request branch"
       is_dont_change_value: true
+  - pull_request_head_branch: "$BITRISEIO_PULL_REQUEST_HEAD_BRANCH"
+    opts:
+      category: "Clone arguments"
+      title: "Pull request head branch"
+      description: |-
+        If the Git hosting provider system supports and provides this, 
+        this special git ref should point to the source of the pull request.
+      is_dont_change_value: true
   - update_submodules: "yes"
     opts:
       category: "Checkout options"

--- a/step.yml
+++ b/step.yml
@@ -54,42 +54,42 @@ inputs:
       is_required: true
   - commit: "$BITRISE_GIT_COMMIT"
     opts:
-      category: Clone Config
+      category: "Clone arguments"
       title: "Git Commit to clone"
       is_dont_change_value: true
   - tag: "$BITRISE_GIT_TAG"
     opts:
-      category: Clone Config
+      category: "Clone arguments"
       title: "Git Tag to clone"
       is_dont_change_value: true
   - branch: "$BITRISE_GIT_BRANCH"
     opts:
-      category: Clone Config
+      category: "Clone arguments"
       title: "Git Branch to clone"
       is_dont_change_value: true
   - branch_dest: "$BITRISEIO_GIT_BRANCH_DEST"
     opts:
-      category: Clone Config
+      category: "Clone arguments"
       title: "Destination git Branch, used for pull requests"
       is_dont_change_value: true
   - pull_request_id: "$PULL_REQUEST_ID"
     opts:
-      category: Clone Config
+      category: "Clone arguments"
       title: "Pull request ID on GitHub"
       is_dont_change_value: true
   - pull_request_repository_url: "$BITRISEIO_PULL_REQUEST_REPOSITORY_URL"
     opts:
-      category: Clone Config
+      category: "Clone arguments"
       title: "Pull request git URL"
       is_dont_change_value: true
   - pull_request_merge_branch: "$BITRISEIO_PULL_REQUEST_MERGE_BRANCH"
     opts:
-      category: Clone Config
+      category: "Clone arguments"
       title: "Merged pull request branch"
       is_dont_change_value: true
   - update_submodules: "yes"
     opts:
-      category: Clone Config
+      category: "Checkout options"
       title: Update the registered submodules?
       summary: |-
         Update the registered submodules?
@@ -100,11 +100,24 @@ inputs:
       - "no"
   - clone_depth:
     opts:
-      category: Clone Config
+      category: "Checkout options"
       title: "Limit fetching to the specified number of commits"
       description: |-
         Limit fetching to the specified number of commits.
         The value should be a decimal number, for example `10`.
+  - merge_pr: "yes"
+    opts:
+      category: "Checkout options"
+      title: "Merge PR head and base branch"
+      summary: "Optional if PR branch is required to be up-to-date."
+      description: |-
+        Allows disabling merging the head and base branches, 
+        in case the git provider has an option to require the PR branch to be up-to-date.
+        - `yes`: The default setting. Merges the head branch into the base branch.
+        - `no`: Treats PR events as push events on the head (source) branch.
+      value_options:
+      - "yes"
+      - "no"
   - reset_repository: "No"
     opts:
       category: Debug


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MINOR_ [version update](https://semver.org/)

### Context

Make PR merge optional, in case git provider allows to set the PR to be required up-to-date before merging.

Resolves: https://bitrise.atlassian.net/browse/STEP-94


### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->
