### PR TITLE
Support shallow cloning submodules

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -74,7 +74,6 @@ workflows:
     - path::./:
         run_if: true
         inputs:
-        - repository_url: git@gitlab.com:bitrise/git-clone-test.git
         - clone_into_dir: $CLONE_INTO_DIR
         - commit: ""
         - tag: ""

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -483,6 +483,50 @@ func Test_checkoutState(t *testing.T) {
 	}
 }
 
+// SubmoduleUpdate
+var submoduleTestCases = [...]struct {
+	name     string
+	cfg      Config
+	wantCmds []string
+}{
+	{
+		name: "Limiting submodule depth",
+		cfg: Config{
+			LimitSubmoduleUpdateDepth: true,
+		},
+		wantCmds: []string{
+			`git "submodule" "update" "--init" "--recursive" "--depth=1"`,
+		},
+	},
+	{
+		name: "Not limiting submodule depth",
+		cfg: Config{
+			LimitSubmoduleUpdateDepth: false,
+		},
+		wantCmds: []string{
+			`git "submodule" "update" "--init" "--recursive"`,
+		},
+	},
+}
+
+func Test_SubmoduleUpdate(t *testing.T) {
+	for _, tt := range submoduleTestCases {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			mockRunner := givenMockRunnerSucceeds()
+			runner = mockRunner
+
+			// When
+			actualErr := updateSubmodules(git.Git{}, tt.cfg)
+
+			// Then
+			assert.NoError(t, actualErr)
+			assert.Equal(t, tt.wantCmds, mockRunner.Cmds())
+		})
+	}
+}
+
+// Mocks
 func givenMockRunner() *MockRunner {
 	mockRunner := new(MockRunner)
 	mockRunner.GivenRunForOutputSucceeds()

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/bitrise-init v0.0.0-20201117094539-a984f01dd477
 	github.com/bitrise-io/envman v0.0.0-20200512105748-919e33f391ee
 	github.com/bitrise-io/go-steputils v0.0.0-20201016102104-03ae3a6ded35
-	github.com/bitrise-io/go-utils v0.0.0-20201019131314-6cc2aa4d248a
+	github.com/bitrise-io/go-utils v0.0.0-20210316133228-449620935158
 	github.com/bitrise-io/goinp v0.0.0-20190611131639-bd18a8681e27 // indirect
 	github.com/bitrise-steplib/bitrise-step-export-universal-apk v0.0.0-20200729103519-a582681d23d6
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/bitrise-io/go-steputils v0.0.0-20201016102104-03ae3a6ded35 h1:iKtx/Rx
 github.com/bitrise-io/go-steputils v0.0.0-20201016102104-03ae3a6ded35/go.mod h1:GXgBV3Frd3qcnsg+NryQTyx1CHjZHr/2w7Bx4WAcB4o=
 github.com/bitrise-io/go-utils v0.0.0-20201019131314-6cc2aa4d248a h1:i1hLZTX2L30oYmaeSnSjDRPQDvwgsFkH4OCr16Vyy+8=
 github.com/bitrise-io/go-utils v0.0.0-20201019131314-6cc2aa4d248a/go.mod h1:tTEsKvbz1LbzuN/KpVFHXnLtcAPdEgIdM41s0lL407s=
+github.com/bitrise-io/go-utils v0.0.0-20210316133228-449620935158 h1:GZjx3KhYSFlfzEXN7Uw48MgFgt0QVU2z3R9KVnbcZ4Y=
+github.com/bitrise-io/go-utils v0.0.0-20210316133228-449620935158/go.mod h1:tTEsKvbz1LbzuN/KpVFHXnLtcAPdEgIdM41s0lL407s=
 github.com/bitrise-io/goinp v0.0.0-20190611131639-bd18a8681e27 h1:NuGIfwKcZvdR1RT4sQ32kE8h35w9XQjQrrCJPJqS4ek=
 github.com/bitrise-io/goinp v0.0.0-20190611131639-bd18a8681e27/go.mod h1:G0M1sK06a1l0KAg4rQei7q5dDKC/JrZoaXFqak91osU=
 github.com/bitrise-steplib/bitrise-step-export-universal-apk v0.0.0-20200729103519-a582681d23d6 h1:7UWHsApY8/iIGw1jVbDiL3FMnI70Y/t0BxG9nQupHhI=

--- a/step.yml
+++ b/step.yml
@@ -108,7 +108,7 @@ inputs:
   - limit_submodule_update_depth: "yes"
     opts:
       category: Clone Config
-      title: "Shalow update submodules"
+      title: "Shallow update submodules"
       summary: "Shoud submodules be shallow cloned with a history truncated to the latest revisions."
       value_options:
         - "yes"

--- a/step.yml
+++ b/step.yml
@@ -1,34 +1,34 @@
 title: "Git Clone Repository"
 summary: The Step checks out the defined repository state, optionally updates the repository submodules and exports the achieved git repository state properties.
 description: |
-   The checkout process depends on the checkout properties: the Step either checks out a repository state defined by a git commit or a git tag, or achieves a merged state of a pull / merge request.
-   The Step uses two solutions to achieve the merged state of the pull / merge request: auto merge in the case of a merge branch or diff file (provided by the Git service) and manual merge otherwise.
-   Once the desired state is checked out, the Step optionally updates the submodules. In the case of pull / merge request, the Step checks out a detach head and exports the achieved git state properties.
+  The checkout process depends on the checkout properties: the Step either checks out a repository state defined by a git commit or a git tag, or achieves a merged state of a pull / merge request.
+  The Step uses two solutions to achieve the merged state of the pull / merge request: auto merge in the case of a merge branch or diff file (provided by the Git service) and manual merge otherwise.
+  Once the desired state is checked out, the Step optionally updates the submodules. In the case of pull / merge request, the Step checks out a detach head and exports the achieved git state properties.
+
+  ### Configuring the Step
+
+  1. The **Git repository URL** and the ** Clone destination (local)directory path** fields are required fields and are automatically filled out based on your project settings.
+  Optionally, you can modify the following fields in the **Clone Config** section:
+  1. You can set the **Update the registered submodules?** option to `yes` to pull the most up-to-date version of the submodule from the submodule's repository.
+  2. You can set the number of commits you want the Step to fetch in the **Limit fetching to the specified number of commits** option. Make sure you set a decimal number.
+
+  Other **Clone config** inputs are not editable unless you go to the **bitrise.yml** tab, however, to avoid issues, we suggest you to contact our Support team instead.
+
+  ### Troubleshooting
+  If you have GitHub Enterprise set up, it works slightly differently on [bitrise.io](https://www.bitrise.io) than on [github.com](https://github.com). You have to manually set the git clone URL, register the SSH key and the webhook.
+  If you face network issues in the case of self-hosted git servers, we advise you to contact our Support Team to help you out.
+  If you face slow clone speed, set the **Limit fetching to the specified number of commits** to the number of commits you want to clone instead of cloning the whole commit history or you can use the Git LFS solution provided by the git provider.
    
-   ### Configuring the Step
+  ### Useful links
+
+  - [How to register a GitHub Enterprise repository](https://discuss.bitrise.io/t/how-to-register-a-github-enterprise-repository/218)
+  - [Code security](https://devcenter.bitrise.io/getting-started/code-security/)
+
+  ### Related Steps
    
-   1. The **Git repository URL** and the ** Clone destination (local)directory path** fields are required fields and are automatically filled out based on your project settings.
-   Optionally, you can modify the following fields in the **Clone Config** section:
-   1. You can set the **Update the registered submodules?** option to `yes` to pull the most up-to-date version of the submodule from the submodule's repository.
-   2. You can set the number of commits you want the Step to fetch in the **Limit fetching to the specified number of commits** option. Make sure you set a decimal number.
-   
-   Other **Clone config** inputs are not editable unless you go to the **bitrise.yml** tab, however, to avoid issues, we suggest you to contact our Support team instead.
-   
-   ### Troubleshooting
-   If you have GitHub Enterprise set up, it works slightly differently on [bitrise.io](https://www.bitrise.io) than on [github.com](https://github.com). You have to manually set the git clone URL, register the SSH key and the webhook.
-   If you face network issues in the case of self-hosted git servers, we advise you to contact our Support Team to help you out.
-   If you face slow clone speed, set the **Limit fetching to the specified number of commits** to the number of commits you want to clone instead of cloning the whole commit history or you can use the Git LFS solution provided by the git provider.
-    
-   ### Useful links
-   
-   - [How to register a GitHub Enterprise repository](https://discuss.bitrise.io/t/how-to-register-a-github-enterprise-repository/218)
-   - [Code security](https://devcenter.bitrise.io/getting-started/code-security/)
-   
-   ### Related Steps
-    
-   - [Activate SSH key (RSA private key)](https://www.bitrise.io/integrations/steps/activate-ssh-key)
-   - [Bitrise.io Cache:Pull](https://www.bitrise.io/integrations/steps/cache-pull)
-   - [Bitrise.io Cache:Push](https://www.bitrise.io/integrations/steps/cache-push)
+  - [Activate SSH key (RSA private key)](https://www.bitrise.io/integrations/steps/activate-ssh-key)
+  - [Bitrise.io Cache:Pull](https://www.bitrise.io/integrations/steps/cache-pull)
+  - [Bitrise.io Cache:Push](https://www.bitrise.io/integrations/steps/cache-push)
 
 website: https://github.com/bitrise-steplib/steps-git-clone
 source_code_url: https://github.com/bitrise-steplib/steps-git-clone
@@ -96,8 +96,8 @@ inputs:
       description: |-
         Update the registered submodules?
       value_options:
-      - "yes"
-      - "no"
+        - "yes"
+        - "no"
   - clone_depth:
     opts:
       category: Clone Config
@@ -105,25 +105,33 @@ inputs:
       description: |-
         Limit fetching to the specified number of commits.
         The value should be a decimal number, for example `10`.
+  - limit_submodule_update_depth: "yes"
+    opts:
+      category: Clone Config
+      title: "Shalow update submodules"
+      summary: "Shoud submodules be shallow cloned with a history truncated to the latest revisions."
+      value_options:
+        - "yes"
+        - "no"
   - reset_repository: "No"
     opts:
       category: Debug
       summary: Reset repository contents with git reset --hard HEAD and git clean -f after repository updated
       title: Reset repository
       value_options:
-      - "No"
-      - "Yes"
+        - "No"
+        - "Yes"
   - manual_merge: "yes"
     opts:
       category: Debug
       title: Manual merge
-      summary:  Prefer to do a manual `git merge` by default.
+      summary: Prefer to do a manual `git merge` by default.
       description: |-
         Prefer to do a manual `git merge` by default.
         When the Pull Request is from a GitHub or Bitbucket private fork repository set this to `"no"`.
       value_options:
-      - "yes"
-      - "no"
+        - "yes"
+        - "no"
   - build_url: "$BITRISE_BUILD_URL"
     opts:
       category: Debug

--- a/step.yml
+++ b/step.yml
@@ -116,7 +116,7 @@ inputs:
   - reset_repository: "No"
     opts:
       category: Debug
-      summary: Reset repository contents with git reset --hard HEAD and git clean -f after repository updated
+      summary: Reset repository contents with git reset --hard HEAD and git clean -f after repository updated.
       title: Reset repository
       value_options:
         - "No"
@@ -128,7 +128,7 @@ inputs:
       summary: Prefer to do a manual `git merge` by default.
       description: |-
         Prefer to do a manual `git merge` by default.
-        When the Pull Request is from a GitHub or Bitbucket private fork repository set this to `"no"`.
+        When the Pull Request is from a GitHub or Bitbucket private fork repository set this to `no`.
       value_options:
         - "yes"
         - "no"

--- a/step.yml
+++ b/step.yml
@@ -109,7 +109,7 @@ inputs:
     opts:
       category: Clone Config
       title: "Shallow update submodules"
-      summary: "Shoud submodules be shallow cloned with a history truncated to the latest revisions."
+      summary: "Should submodules be shallow cloned with a history truncated to the latest revisions."
       value_options:
         - "yes"
         - "no"

--- a/vendor/github.com/bitrise-io/go-utils/command/command.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/command.go
@@ -2,14 +2,11 @@ package command
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
-
-	"github.com/bitrise-io/go-utils/errorutil"
 )
 
 // ----------
@@ -139,18 +136,10 @@ func PrintableCommandArgs(isQuoteFirst bool, fullCommandArgs []string) string {
 }
 
 // RunCmdAndReturnExitCode ...
-func RunCmdAndReturnExitCode(cmd *exec.Cmd) (int, error) {
-	err := cmd.Run()
-	if err != nil {
-		exitCode, castErr := errorutil.CmdExitCodeFromError(err)
-		if castErr != nil {
-			return 1, fmt.Errorf("failed get exit code from error: %s, error: %s", err, castErr)
-		}
-
-		return exitCode, err
-	}
-
-	return 0, nil
+func RunCmdAndReturnExitCode(cmd *exec.Cmd) (exitCode int, err error) {
+	err = cmd.Run()
+	exitCode = cmd.ProcessState.ExitCode()
+	return
 }
 
 // RunCmdAndReturnTrimmedOutput ...

--- a/vendor/github.com/bitrise-io/go-utils/command/git/commands.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/git/commands.go
@@ -62,8 +62,12 @@ func (g *Git) Clean(options ...string) *command.Model {
 }
 
 // SubmoduleUpdate updates the registered submodules.
-func (g *Git) SubmoduleUpdate() *command.Model {
-	return g.command("submodule", "update", "--init", "--recursive")
+func (g *Git) SubmoduleUpdate(shallowCheckout bool) *command.Model {
+	args := []string{"submodule", "update", "--init", "--recursive"}
+	if shallowCheckout {
+		args = append(args, "--depth=1")
+	}
+	return g.command(args...)
 }
 
 // SubmoduleForeach evaluates an arbitrary git command in each checked out

--- a/vendor/github.com/bitrise-io/go-utils/errorutil/errorutil.go
+++ b/vendor/github.com/bitrise-io/go-utils/errorutil/errorutil.go
@@ -1,19 +1,26 @@
+// Package errorutil ...
 package errorutil
 
 import (
-	"errors"
 	"os/exec"
 	"regexp"
-	"syscall"
 )
+
+func exitCode(err error) int {
+	if exitError, ok := err.(*exec.ExitError); ok {
+		return exitError.ProcessState.ExitCode()
+	}
+	return -1
+}
 
 // IsExitStatusError ...
 func IsExitStatusError(err error) bool {
-	return IsExitStatusErrorStr(err.Error())
+	return exitCode(err) != -1
 }
 
 // IsExitStatusErrorStr ...
 func IsExitStatusErrorStr(errString string) bool {
+	// https://golang.org/src/os/exec_posix.go?s=2421:2459#L87
 	// example exit status error string: exit status 1
 	var rex = regexp.MustCompile(`^exit status [0-9]{1,3}$`)
 	return rex.MatchString(errString)
@@ -21,16 +28,5 @@ func IsExitStatusErrorStr(errString string) bool {
 
 // CmdExitCodeFromError ...
 func CmdExitCodeFromError(err error) (int, error) {
-	cmdExitCode := 0
-	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			waitStatus, ok := exitError.Sys().(syscall.WaitStatus)
-			if !ok {
-				return 1, errors.New("Failed to cast exit status")
-			}
-			cmdExitCode = waitStatus.ExitStatus()
-		}
-		return cmdExitCode, nil
-	}
-	return 0, nil
+	return exitCode(err), err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/bitrise-io/envman/models
 github.com/bitrise-io/go-steputils/input
 github.com/bitrise-io/go-steputils/stepconf
 github.com/bitrise-io/go-steputils/tools
-# github.com/bitrise-io/go-utils v0.0.0-20201019131314-6cc2aa4d248a
+# github.com/bitrise-io/go-utils v0.0.0-20210316133228-449620935158
 ## explicit
 github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires MINOR [version update](https://semver.org/)

### Context

Support shallow cloning submodules to speed up cloning of repositories with submodules.

Resolves: [STEP-51](https://bitrise.atlassian.net/browse/STEP-51)

### Changes

- Updated `github.com/bitrise-io/go-utils/command/git`
- Introduced `limit_submodule_update_depth` input with default value of `yes`. If input has `yes` value that submodules will be cloned with the `--depth=1` argument.
- Create tests to cover the case.
