### PR TITLE
Revert `--jobs` flag inclusion as old `git` version doesn't support it

### DIFF
--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -35,8 +35,6 @@ const (
 
 func fetch(gitCmd git.Git, remote string, ref string, traits fetchOptions) error {
 	var opts []string
-	opts = append(opts, jobsFlag)
-
 	if traits.depth != 0 {
 		opts = append(opts, "--depth="+strconv.Itoa(traits.depth))
 	}

--- a/gitclone/git.go
+++ b/gitclone/git.go
@@ -14,7 +14,6 @@ import (
 const (
 	checkoutFailedTag = "checkout_failed"
 	fetchFailedTag    = "fetch_failed"
-	jobsFlag          = "--jobs=10"
 )
 
 var runner CommandRunner = DefaultRunner{}
@@ -123,7 +122,7 @@ type getAvailableBranches func() (map[string][]string, error)
 
 func listBranches(gitCmd git.Git) getAvailableBranches {
 	return func() (map[string][]string, error) {
-		if err := runner.Run(gitCmd.Fetch(jobsFlag)); err != nil {
+		if err := runner.Run(gitCmd.Fetch()); err != nil {
 			return nil, err
 		}
 		out, err := runner.RunForOutput(gitCmd.Branch("-r"))

--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -89,7 +89,7 @@ func checkoutState(gitCmd git.Git, cfg Config, patch patchSource) error {
 }
 
 func updateSubmodules(gitCmd git.Git, cfg Config) error {
-	if err := runner.Run(gitCmd.SubmoduleUpdate(cfg.LimitSubmoduleUpdateDepth, jobsFlag)); err != nil {
+	if err := runner.Run(gitCmd.SubmoduleUpdate(cfg.LimitSubmoduleUpdateDepth)); err != nil {
 		return newStepError(
 			updateSubmodelFailedTag,
 			fmt.Errorf("submodule update: %v", err),

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -34,7 +34,7 @@ var testCases = [...]struct {
 			CloneDepth: 1,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules"`,
 			`git "checkout" "76a934a"`,
 		},
 	},
@@ -45,7 +45,7 @@ var testCases = [...]struct {
 			Branch: "hcnarb",
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -56,8 +56,8 @@ var testCases = [...]struct {
 		},
 		mockRunner: givenMockRunnerSucceedsAfter(1),
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--no-recurse-submodules"`,
-			`git "fetch" "--jobs=10" "--no-recurse-submodules"`,
+			`git "fetch" "--no-recurse-submodules"`,
+			`git "fetch" "--no-recurse-submodules"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -68,7 +68,7 @@ var testCases = [...]struct {
 			CloneDepth: 1,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 			`git "checkout" "hcnarb"`,
 			`git "merge" "origin/hcnarb"`,
 		},
@@ -80,7 +80,7 @@ var testCases = [...]struct {
 			CloneDepth: 1,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "--tags" "--no-recurse-submodules"`,
+			`git "fetch" "--depth=1" "--tags" "--no-recurse-submodules"`,
 			`git "checkout" "gat"`,
 		},
 	},
@@ -91,7 +91,7 @@ var testCases = [...]struct {
 			Branch: "hcnarb",
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+			`git "fetch" "--tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 			`git "checkout" "gat"`,
 		},
 	},
@@ -102,7 +102,7 @@ var testCases = [...]struct {
 			Branch: "gat",
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--tags" "--no-recurse-submodules" "origin" "refs/heads/gat"`,
+			`git "fetch" "--tags" "--no-recurse-submodules" "origin" "refs/heads/gat"`,
 			`git "checkout" "gat"`,
 		},
 	},
@@ -114,7 +114,7 @@ var testCases = [...]struct {
 			Branch: "hcnarb",
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+			`git "fetch" "--tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -125,7 +125,7 @@ var testCases = [...]struct {
 			Tag:    "gat",
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--tags" "--no-recurse-submodules"`,
+			`git "fetch" "--tags" "--no-recurse-submodules"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -143,11 +143,11 @@ var testCases = [...]struct {
 			ShouldMergePR: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,     // Already on 'master'
 			`git "merge" "origin/master"`, // Already up to date.
 			`git "log" "-1" "--format=%H"`,
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
 			`git "checkout" "--detach"`,
 		},
@@ -162,11 +162,11 @@ var testCases = [...]struct {
 			ShouldMergePR: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
 			`git "checkout" "--detach"`,
 		},
@@ -184,12 +184,12 @@ var testCases = [...]struct {
 			ShouldMergePR:         true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
 			`git "remote" "add" "fork" "https://github.com/bitrise-io/other-repo.git"`,
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "fork" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "fork" "refs/heads/test/commit-messages"`,
 			`git "merge" "fork/test/commit-messages"`,
 			`git "checkout" "--detach"`,
 		},
@@ -207,11 +207,11 @@ var testCases = [...]struct {
 			ShouldMergePR:         true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
 			`git "checkout" "--detach"`,
 		},
@@ -228,8 +228,8 @@ var testCases = [...]struct {
 			ShouldMergePR: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/pull/5/head:pull/5"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/pull/5/head:pull/5"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "merge" "pull/5"`,
@@ -244,8 +244,8 @@ var testCases = [...]struct {
 			ShouldMergePR: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/master"`,
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/pr_test:pr_test"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/pr_test:pr_test"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "merge" "pr_test"`, // warning: refname 'pr_test' is ambiguous.
@@ -265,8 +265,8 @@ var testCases = [...]struct {
 			ShouldMergePR:         true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/master"`,
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/pull/7/head:pull/7"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/pull/7/head:pull/7"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "merge" "pull/7"`,
@@ -291,10 +291,10 @@ var testCases = [...]struct {
 			GivenRunWithRetryFailsAfter(2).
 			GivenRunSucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "origin" "refs/heads/master"`,
-			`git "fetch" "--jobs=10" "origin" "refs/heads/master"`,
-			`git "fetch" "--jobs=10" "origin" "refs/heads/master"`,
-			`git "fetch" "--jobs=10"`,
+			`git "fetch" "origin" "refs/heads/master"`,
+			`git "fetch" "origin" "refs/heads/master"`,
+			`git "fetch" "origin" "refs/heads/master"`,
+			`git "fetch"`,
 			`git "branch" "-r"`,
 		},
 		wantErrType: &step.Error{},
@@ -314,7 +314,7 @@ var testCases = [...]struct {
 		patchSource: MockPatchSource{"diff_path", nil},
 		wantErr:     nil,
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
 			`git "checkout" "--detach"`,
@@ -338,14 +338,14 @@ var testCases = [...]struct {
 			GivenRunWithRetrySucceeds().
 			GivenRunSucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
 			`git "checkout" "--detach"`,
 		},
@@ -368,15 +368,15 @@ var testCases = [...]struct {
 			GivenRunWithRetrySucceeds().
 			GivenRunSucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
 			`git "remote" "add" "fork" "git@github.com:bitrise-io/other-repo.git"`,
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "fork" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--no-recurse-submodules" "fork" "refs/heads/test/commit-messages"`,
 			`git "merge" "fork/test/commit-messages"`,
 			`git "checkout" "--detach"`,
 		},
@@ -395,7 +395,7 @@ var testCases = [...]struct {
 			UpdateSubmodules: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "origin" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/test/commit-messages"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -411,7 +411,7 @@ var testCases = [...]struct {
 			UpdateSubmodules: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "origin" "refs/pull/5/head"`,
+			`git "fetch" "--depth=1" "origin" "refs/pull/5/head"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -432,7 +432,7 @@ var testCases = [...]struct {
 		wantErr:     nil,
 		wantCmds: []string{
 			`git "remote" "add" "fork" "https://github.com/bitrise-io/git-clone-test2.git"`,
-			`git "fetch" "--jobs=10" "--depth=1" "fork" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--depth=1" "fork" "refs/heads/test/commit-messages"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -453,7 +453,7 @@ var testCases = [...]struct {
 		patchSource: MockPatchSource{"diff_path", nil},
 		wantErr:     nil,
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
 			`git "checkout" "--detach"`,
@@ -470,10 +470,10 @@ var testCases = [...]struct {
 			GivenRunWithRetryFailsAfter(2).
 			GivenRunSucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
-			`git "fetch" "--jobs=10" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
-			`git "fetch" "--jobs=10"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
+			`git "fetch" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
+			`git "fetch"`,
 			`git "branch" "-r"`,
 		},
 		wantErr: newStepErrorWithBranchRecommendations(
@@ -510,11 +510,11 @@ var testCases = [...]struct {
 			GivenRunWithRetrySucceeds().
 			GivenRunSucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1"`,
+			`git "fetch" "--depth=1"`,
 			`git "checkout" "cfba2b01332e31cb1568dbf3f22edce063118bae"`,
 			// fatal: reference is not a tree: cfba2b01332e31cb1568dbf3f22edce063118bae
 			// Checkout failed, error: fatal: reference is not a tree: cfba2b01332e31cb1568dbf3f22edce063118bae
-			`git "fetch" "--jobs=10" "--unshallow"`,
+			`git "fetch" "--unshallow"`,
 			`git "checkout" "cfba2b01332e31cb1568dbf3f22edce063118bae"`,
 		},
 	},
@@ -544,8 +544,8 @@ var testCases = [...]struct {
 			GivenRunSucceeds().
 			GivenRunWithRetrySucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
-			`git "fetch" "--jobs=10" "--depth=1" "--no-recurse-submodules" "origin" "refs/pull/5/head:pull/5"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--depth=1" "--no-recurse-submodules" "origin" "refs/pull/5/head:pull/5"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "merge" "pull/5"`,
@@ -555,7 +555,7 @@ var testCases = [...]struct {
 			`git "clean" "-x" "-d" "-f"`,
 			`git "submodule" "foreach" "git" "reset" "--hard" "HEAD"`,
 			`git "submodule" "foreach" "git" "clean" "-x" "-d" "-f"`,
-			`git "fetch" "--jobs=10" "--unshallow"`,
+			`git "fetch" "--unshallow"`,
 			`git "merge" "pull/5"`,
 			`git "checkout" "--detach"`,
 		},
@@ -603,7 +603,7 @@ var submoduleTestCases = [...]struct {
 			LimitSubmoduleUpdateDepth: true,
 		},
 		wantCmds: []string{
-			`git "submodule" "update" "--init" "--recursive" "--jobs=10" "--depth=1"`,
+			`git "submodule" "update" "--init" "--recursive" "--depth=1"`,
 		},
 	},
 	{
@@ -612,7 +612,7 @@ var submoduleTestCases = [...]struct {
 			LimitSubmoduleUpdateDepth: false,
 		},
 		wantCmds: []string{
-			`git "submodule" "update" "--init" "--recursive" "--jobs=10"`,
+			`git "submodule" "update" "--init" "--recursive"`,
 		},
 	},
 }

--- a/gitclone/unshallow.go
+++ b/gitclone/unshallow.go
@@ -16,8 +16,14 @@ type simpleUnshallow struct{}
 
 func (s simpleUnshallow) do(gitCmd git.Git) error {
 	log.Infof("Fetch with unshallow...")
-	return unshallowFetch(gitCmd)
 
+	if err := runner.RunWithRetry(func() *command.Model {
+		return gitCmd.Fetch("--unshallow")
+	}); err != nil {
+		return fmt.Errorf("fetch failed: %v", err)
+	}
+
+	return nil
 }
 
 type resetUnshallow struct{}
@@ -28,13 +34,8 @@ func (r resetUnshallow) do(gitCmd git.Git) error {
 	if err := resetRepo(gitCmd); err != nil {
 		return fmt.Errorf("reset repository: %v", err)
 	}
-
-	return unshallowFetch(gitCmd)
-}
-
-func unshallowFetch(gitCmd git.Git) error {
 	if err := runner.RunWithRetry(func() *command.Model {
-		return gitCmd.Fetch(jobsFlag, "--unshallow")
+		return gitCmd.Fetch("--unshallow")
 	}); err != nil {
 		return fmt.Errorf("fetch failed: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/bitrise-init v0.0.0-20201117094539-a984f01dd477
 	github.com/bitrise-io/envman v0.0.0-20200512105748-919e33f391ee
 	github.com/bitrise-io/go-steputils v0.0.0-20201016102104-03ae3a6ded35
-	github.com/bitrise-io/go-utils v0.0.0-20210318101856-947ef8d6c529
+	github.com/bitrise-io/go-utils v0.0.0-20210316133228-449620935158
 	github.com/bitrise-io/goinp v0.0.0-20190611131639-bd18a8681e27 // indirect
 	github.com/bitrise-steplib/bitrise-step-export-universal-apk v0.0.0-20200729103519-a582681d23d6
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/bitrise-io/go-utils v0.0.0-20201019131314-6cc2aa4d248a h1:i1hLZTX2L30
 github.com/bitrise-io/go-utils v0.0.0-20201019131314-6cc2aa4d248a/go.mod h1:tTEsKvbz1LbzuN/KpVFHXnLtcAPdEgIdM41s0lL407s=
 github.com/bitrise-io/go-utils v0.0.0-20210316133228-449620935158 h1:GZjx3KhYSFlfzEXN7Uw48MgFgt0QVU2z3R9KVnbcZ4Y=
 github.com/bitrise-io/go-utils v0.0.0-20210316133228-449620935158/go.mod h1:tTEsKvbz1LbzuN/KpVFHXnLtcAPdEgIdM41s0lL407s=
-github.com/bitrise-io/go-utils v0.0.0-20210318101856-947ef8d6c529 h1:v5A0gM1s1FTNcpAhmAQJnw0obZFH+hvNJfspDnz4jT8=
-github.com/bitrise-io/go-utils v0.0.0-20210318101856-947ef8d6c529/go.mod h1:tTEsKvbz1LbzuN/KpVFHXnLtcAPdEgIdM41s0lL407s=
 github.com/bitrise-io/goinp v0.0.0-20190611131639-bd18a8681e27 h1:NuGIfwKcZvdR1RT4sQ32kE8h35w9XQjQrrCJPJqS4ek=
 github.com/bitrise-io/goinp v0.0.0-20190611131639-bd18a8681e27/go.mod h1:G0M1sK06a1l0KAg4rQei7q5dDKC/JrZoaXFqak91osU=
 github.com/bitrise-steplib/bitrise-step-export-universal-apk v0.0.0-20200729103519-a582681d23d6 h1:7UWHsApY8/iIGw1jVbDiL3FMnI70Y/t0BxG9nQupHhI=

--- a/vendor/github.com/bitrise-io/go-utils/command/git/commands.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/git/commands.go
@@ -62,9 +62,8 @@ func (g *Git) Clean(options ...string) *command.Model {
 }
 
 // SubmoduleUpdate updates the registered submodules.
-func (g *Git) SubmoduleUpdate(shallowCheckout bool, opts ...string) *command.Model {
+func (g *Git) SubmoduleUpdate(shallowCheckout bool) *command.Model {
 	args := []string{"submodule", "update", "--init", "--recursive"}
-	args = append(args, opts...)
 	if shallowCheckout {
 		args = append(args, "--depth=1")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/bitrise-io/envman/models
 github.com/bitrise-io/go-steputils/input
 github.com/bitrise-io/go-steputils/stepconf
 github.com/bitrise-io/go-steputils/tools
-# github.com/bitrise-io/go-utils v0.0.0-20210318101856-947ef8d6c529
+# github.com/bitrise-io/go-utils v0.0.0-20210316133228-449620935158
 ## explicit
 github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command


### PR DESCRIPTION
### Checklist

- [✅ ] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)

### Context

Revert STEP-680 until we release `git` update on all stacks

### Changes

- Revert `--jobs` changes
