### PR TITLE
Introduce `--jobs` flag on fetch and submodule update commands

### DIFF
--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -38,6 +38,8 @@ const (
 
 func fetch(gitCmd git.Git, remote string, ref string, traits fetchOptions) error {
 	var opts []string
+	opts = append(opts, jobsFlag)
+
 	if traits.depth != 0 {
 		opts = append(opts, "--depth="+strconv.Itoa(traits.depth))
 	}

--- a/gitclone/git.go
+++ b/gitclone/git.go
@@ -14,6 +14,7 @@ import (
 const (
 	checkoutFailedTag = "checkout_failed"
 	fetchFailedTag    = "fetch_failed"
+	jobsFlag          = "--jobs=10"
 )
 
 var runner CommandRunner = DefaultRunner{}
@@ -122,7 +123,7 @@ type getAvailableBranches func() (map[string][]string, error)
 
 func listBranches(gitCmd git.Git) getAvailableBranches {
 	return func() (map[string][]string, error) {
-		if err := runner.Run(gitCmd.Fetch()); err != nil {
+		if err := runner.Run(gitCmd.Fetch(jobsFlag)); err != nil {
 			return nil, err
 		}
 		out, err := runner.RunForOutput(gitCmd.Branch("-r"))

--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -93,7 +93,7 @@ func checkoutState(gitCmd git.Git, cfg Config, patch patchSource) error {
 }
 
 func updateSubmodules(gitCmd git.Git, cfg Config) error {
-	if err := runner.Run(gitCmd.SubmoduleUpdate(cfg.LimitSubmoduleUpdateDepth)); err != nil {
+	if err := runner.Run(gitCmd.SubmoduleUpdate(cfg.LimitSubmoduleUpdateDepth, jobsFlag)); err != nil {
 		return newStepError(
 			updateSubmodelFailedTag,
 			fmt.Errorf("submodule update: %v", err),

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -569,7 +569,7 @@ var testCases = [...]struct {
 			SparseDirectories: []string{"client/android"},
 		},
 		wantCmds: []string{
-			`git "fetch" "--filter=tree:0" "--no-tags" "--no-recurse-submodules"`,
+			`git "fetch" "--jobs=10" "--filter=tree:0" "--no-tags" "--no-recurse-submodules"`,
 			`git "checkout" "76a934a"`,
 		},
 	},
@@ -581,7 +581,7 @@ var testCases = [...]struct {
 			SparseDirectories: []string{"client/android"},
 		},
 		wantCmds: []string{
-			`git "fetch" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+			`git "fetch" "--jobs=10" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -593,7 +593,7 @@ var testCases = [...]struct {
 			SparseDirectories: []string{"client/android"},
 		},
 		wantCmds: []string{
-			`git "fetch" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+			`git "fetch" "--jobs=10" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 			`git "checkout" "hcnarb"`,
 			`git "merge" "origin/hcnarb"`,
 		},
@@ -606,7 +606,7 @@ var testCases = [...]struct {
 			SparseDirectories: []string{"client/android"},
 		},
 		wantCmds: []string{
-			`git "fetch" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
+			`git "fetch" "--jobs=10" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
 			`git "checkout" "gat"`,
 		},
 	},

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -34,7 +34,7 @@ var testCases = [...]struct {
 			CloneDepth: 1,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules"`,
 			`git "checkout" "76a934a"`,
 		},
 	},
@@ -46,7 +46,7 @@ var testCases = [...]struct {
 			FetchTags: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+			`git "fetch" "--jobs=10" "--tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -57,8 +57,8 @@ var testCases = [...]struct {
 		},
 		mockRunner: givenMockRunnerSucceedsAfter(1),
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "--no-recurse-submodules"`,
-			`git "fetch" "--no-tags" "--no-recurse-submodules"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -69,7 +69,7 @@ var testCases = [...]struct {
 			CloneDepth: 1,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 			`git "checkout" "hcnarb"`,
 			`git "merge" "origin/hcnarb"`,
 		},
@@ -81,7 +81,7 @@ var testCases = [...]struct {
 			CloneDepth: 1,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
 			`git "checkout" "gat"`,
 		},
 	},
@@ -91,7 +91,7 @@ var testCases = [...]struct {
 			Tag: "gat",
 		},
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
 			`git "checkout" "gat"`,
 		},
 	},
@@ -101,7 +101,7 @@ var testCases = [...]struct {
 			Tag: "gat",
 		},
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
 			`git "checkout" "gat"`,
 		},
 	},
@@ -113,7 +113,7 @@ var testCases = [...]struct {
 			Branch: "hcnarb",
 		},
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -124,7 +124,7 @@ var testCases = [...]struct {
 			Tag:    "gat",
 		},
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "--no-recurse-submodules"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -142,11 +142,11 @@ var testCases = [...]struct {
 			ShouldMergePR: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,     // Already on 'master'
 			`git "merge" "origin/master"`, // Already up to date.
 			`git "log" "-1" "--format=%H"`,
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
 			`git "checkout" "--detach"`,
 		},
@@ -161,11 +161,11 @@ var testCases = [...]struct {
 			ShouldMergePR: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
 			`git "checkout" "--detach"`,
 		},
@@ -183,12 +183,12 @@ var testCases = [...]struct {
 			ShouldMergePR:         true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
 			`git "remote" "add" "fork" "https://github.com/bitrise-io/other-repo.git"`,
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "fork" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "fork" "refs/heads/test/commit-messages"`,
 			`git "merge" "fork/test/commit-messages"`,
 			`git "checkout" "--detach"`,
 		},
@@ -206,11 +206,11 @@ var testCases = [...]struct {
 			ShouldMergePR:         true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
 			`git "checkout" "--detach"`,
 		},
@@ -227,8 +227,8 @@ var testCases = [...]struct {
 			ShouldMergePR: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/5/head:pull/5"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/5/head:pull/5"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "merge" "pull/5"`,
@@ -243,8 +243,8 @@ var testCases = [...]struct {
 			ShouldMergePR: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/pr_test:pr_test"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/pr_test:pr_test"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "merge" "pr_test"`, // warning: refname 'pr_test' is ambiguous.
@@ -264,8 +264,8 @@ var testCases = [...]struct {
 			ShouldMergePR:         true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/7/head:pull/7"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/7/head:pull/7"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "merge" "pull/7"`,
@@ -290,10 +290,10 @@ var testCases = [...]struct {
 			GivenRunWithRetryFailsAfter(2).
 			GivenRunSucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "origin" "refs/heads/master"`,
-			`git "fetch" "--no-tags" "origin" "refs/heads/master"`,
-			`git "fetch" "--no-tags" "origin" "refs/heads/master"`,
-			`git "fetch"`,
+			`git "fetch" "--jobs=10" "--no-tags" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--no-tags" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--no-tags" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10"`,
 			`git "branch" "-r"`,
 		},
 		wantErrType: &step.Error{},
@@ -313,7 +313,7 @@ var testCases = [...]struct {
 		patchSource: MockPatchSource{"diff_path", nil},
 		wantErr:     nil,
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
 			`git "checkout" "--detach"`,
@@ -337,14 +337,14 @@ var testCases = [...]struct {
 			GivenRunWithRetrySucceeds().
 			GivenRunSucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
 			`git "merge" "76a934ae"`,
 			`git "checkout" "--detach"`,
 		},
@@ -367,15 +367,15 @@ var testCases = [...]struct {
 			GivenRunWithRetrySucceeds().
 			GivenRunSucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "log" "-1" "--format=%H"`,
 			`git "remote" "add" "fork" "git@github.com:bitrise-io/other-repo.git"`,
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "fork" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "fork" "refs/heads/test/commit-messages"`,
 			`git "merge" "fork/test/commit-messages"`,
 			`git "checkout" "--detach"`,
 		},
@@ -394,7 +394,7 @@ var testCases = [...]struct {
 			UpdateSubmodules: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "origin" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "origin" "refs/heads/test/commit-messages"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -410,7 +410,7 @@ var testCases = [...]struct {
 			UpdateSubmodules: true,
 		},
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "origin" "refs/pull/5/head"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "origin" "refs/pull/5/head"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -431,7 +431,7 @@ var testCases = [...]struct {
 		wantErr:     nil,
 		wantCmds: []string{
 			`git "remote" "add" "fork" "https://github.com/bitrise-io/git-clone-test2.git"`,
-			`git "fetch" "--depth=1" "--no-tags" "fork" "refs/heads/test/commit-messages"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "fork" "refs/heads/test/commit-messages"`,
 			`git "checkout" "76a934ae"`,
 		},
 	},
@@ -452,7 +452,7 @@ var testCases = [...]struct {
 		patchSource: MockPatchSource{"diff_path", nil},
 		wantErr:     nil,
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "origin" "refs/heads/master"`,
 			`git "checkout" "master"`,
 			`git "apply" "--index" "diff_path"`,
 			`git "checkout" "--detach"`,
@@ -469,10 +469,10 @@ var testCases = [...]struct {
 			GivenRunWithRetryFailsAfter(2).
 			GivenRunSucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
-			`git "fetch" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
-			`git "fetch"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
+			`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
+			`git "fetch" "--jobs=10"`,
 			`git "branch" "-r"`,
 		},
 		wantErr: newStepErrorWithBranchRecommendations(
@@ -509,11 +509,11 @@ var testCases = [...]struct {
 			GivenRunWithRetrySucceeds().
 			GivenRunSucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags"`,
 			`git "checkout" "cfba2b01332e31cb1568dbf3f22edce063118bae"`,
 			// fatal: reference is not a tree: cfba2b01332e31cb1568dbf3f22edce063118bae
 			// Checkout failed, error: fatal: reference is not a tree: cfba2b01332e31cb1568dbf3f22edce063118bae
-			`git "fetch" "--unshallow" "--no-tags"`,
+			`git "fetch" "--jobs=10" "--unshallow" "--no-tags"`,
 			`git "checkout" "cfba2b01332e31cb1568dbf3f22edce063118bae"`,
 		},
 	},
@@ -543,8 +543,8 @@ var testCases = [...]struct {
 			GivenRunSucceeds().
 			GivenRunWithRetrySucceeds(),
 		wantCmds: []string{
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
-			`git "fetch" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/5/head:pull/5"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+			`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/5/head:pull/5"`,
 			`git "checkout" "master"`,
 			`git "merge" "origin/master"`,
 			`git "merge" "pull/5"`,
@@ -554,7 +554,7 @@ var testCases = [...]struct {
 			`git "clean" "-x" "-d" "-f"`,
 			`git "submodule" "foreach" "git" "reset" "--hard" "HEAD"`,
 			`git "submodule" "foreach" "git" "clean" "-x" "-d" "-f"`,
-			`git "fetch" "--unshallow" "--no-tags" "--no-recurse-submodules"`,
+			`git "fetch" "--jobs=10" "--unshallow" "--no-tags" "--no-recurse-submodules"`,
 			`git "merge" "pull/5"`,
 			`git "checkout" "--detach"`,
 		},
@@ -653,7 +653,7 @@ var submoduleTestCases = [...]struct {
 			LimitSubmoduleUpdateDepth: true,
 		},
 		wantCmds: []string{
-			`git "submodule" "update" "--init" "--recursive" "--depth=1"`,
+			`git "submodule" "update" "--init" "--recursive" "--jobs=10" "--depth=1"`,
 		},
 	},
 	{
@@ -662,7 +662,7 @@ var submoduleTestCases = [...]struct {
 			LimitSubmoduleUpdateDepth: false,
 		},
 		wantCmds: []string{
-			`git "submodule" "update" "--init" "--recursive"`,
+			`git "submodule" "update" "--init" "--recursive" "--jobs=10"`,
 		},
 	},
 }

--- a/gitclone/unshallow.go
+++ b/gitclone/unshallow.go
@@ -48,7 +48,7 @@ func (r resetUnshallow) do(gitCmd git.Git) error {
 }
 
 func unshallowFetch(gitCmd git.Git, traits unshallowFetchOptions) error {
-	opts := []string{"--unshallow"}
+	opts := []string{jobsFlag, "--unshallow"}
 	if traits.tags {
 		opts = append(opts, "--tags")
 	} else {


### PR DESCRIPTION
### Checklist

- [✅ ] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Adding `--jobs` flag to improve fetch speed

Resolves: https://bitrise.atlassian.net/browse/STEP-680

### Changes

- Introduced `--jobs` flag for `fetch` and `submodule update` commands
- Updated test cases

### Investigation details

https://bitrise.atlassian.net/wiki/spaces/STEP/pages/1325236987/Git+Clone+Step+--jobs+flag+investigation
