### PR TITLE
If error is present return it instead of success

### DIFF
--- a/gitclone/checkout_method_pr_manual.go
+++ b/gitclone/checkout_method_pr_manual.go
@@ -87,7 +87,7 @@ func (c checkoutPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fal
 	// Fetch and merge
 	sourceBranchRef := refsHeadsPrefix + c.params.SourceBranch
 	if err := fetch(gitCmd, remoteName, sourceBranchRef, fetchOptions); err != nil {
-		return nil
+		return err
 	}
 
 	if err := mergeWithCustomRetry(gitCmd, c.params.SourceMergeArg, fallback); err != nil {


### PR DESCRIPTION
### Checklist

- [✅] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

In the manual merge case when the step fails to fetch content from the remote it didn't fail but returned with success but didn't do what it intended.

Resolves: #159 

### Changes

- Properly return an error when it occurs
