### PR TITLE
Remove `run_if` condition to allow for use in non-CI environments

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -38,7 +38,6 @@ type_tags:
 is_requires_admin_user: false
 is_always_run: false
 is_skippable: false
-run_if: .IsCI
 deps:
   brew:
   - name: git-lfs


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Seems like a _MINOR_ bump would be appropriate.

### Context

@russellbstephens and I were working on the e2e tests of a new step that he's building, and we wanted to do a git clone as a part of one of his e2e tests. We wanted to specify the clone depth, which isn't an option on the [simple-git-clone](https://github.com/bitrise-steplib/bitrise-step-simple-git-clone), so we switched over to use this Step instead.

We noticed when trying to run it locally that it kept skipping, and it turns out it's because the Step is set to only be run in CI.

From some discussion in Slack, it sounds like this Step is generally intended to be used in CI, but I think there are instances where we'd want to be able to run it locally. I don't believe it needs to be restricted here.

(fwiw, I know there are workarounds, but I still think this would be a good change so workarounds aren't needed.)

### Changes

- Removes the `run_if: .IsCI` property from the step's `step.yml` file.
