### PR TITLE
Add method for determining the ideal default clone depth based if the…

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -521,7 +521,7 @@ workflows:
             check "GIT_CLONE_COMMIT_HASH" "76a934ae80f12bb9b504bbc86f64a1d310e5db64"
             check "GIT_CLONE_COMMIT_MESSAGE_SUBJECT" "Sample commit message subject"
             check "GIT_CLONE_COMMIT_MESSAGE_BODY" "Sample commit message body"
-            check "GIT_CLONE_COMMIT_COUNT" "25"
+            check "GIT_CLONE_COMMIT_COUNT" "1"
             check "GIT_CLONE_COMMIT_AUTHOR_NAME" "Krisztian Dobmayer"
             check "GIT_CLONE_COMMIT_AUTHOR_EMAIL" "krisztian.dobmayer@bitrise.io"
             check "GIT_CLONE_COMMIT_COMMITTER_NAME" "Krisztian Dobmayer"

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -22,6 +22,7 @@ workflows:
     - BRANCH: test/generate-changelog
     - FETCH_TAGS: "yes"
     - UPDATE_SUBMODULES: "no"
+    - CLONE_DEPTH: 50
     before_run:
     - _setup
     after_run:
@@ -36,6 +37,7 @@ workflows:
     - BRANCH: test/generate-changelog
     - FETCH_TAGS: "yes"
     - UPDATE_SUBMODULES: "no"
+    - CLONE_DEPTH: 50
     before_run:
     - _setup
     after_run:
@@ -480,7 +482,7 @@ workflows:
         inputs:
         - content: |-
             #!/bin/env bash
-            set -ex
+            set -e
 
             EXPECTED_CHANGELOG="* [a409478] Add newline to the description.
             * [b002ab7] Add repository description.
@@ -491,6 +493,11 @@ workflows:
                 echo "Expected changelog generated."
             else
                 echo "Invalid changelog generated:"
+                echo ""
+                echo "Expected changelog:"
+                echo "$EXPECTED_CHANGELOG"
+                echo ""
+                echo "Generated changelog:"
                 echo "$BITRISE_CHANGELOG"
                 exit 1
             fi
@@ -602,6 +609,7 @@ workflows:
               envman add --key WORKDIR_ABSOLUTE --value $WD
             fi
     - path::./:
+        run_if: "true"
         inputs:
         - repository_url: $TEST_REPO_URL
         - clone_into_dir: $WORKDIR

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -22,7 +22,7 @@ workflows:
     - BRANCH: test/generate-changelog
     - FETCH_TAGS: "yes"
     - UPDATE_SUBMODULES: "no"
-    - CLONE_DEPTH: 50
+    - CLONE_DEPTH: 78
     before_run:
     - _setup
     after_run:
@@ -37,7 +37,7 @@ workflows:
     - BRANCH: test/generate-changelog
     - FETCH_TAGS: "yes"
     - UPDATE_SUBMODULES: "no"
-    - CLONE_DEPTH: 50
+    - CLONE_DEPTH: 46
     before_run:
     - _setup
     after_run:

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -299,7 +299,6 @@ func selectFetchOptions(method CheckoutMethod, cloneDepth int, fetchTags, fetchS
 		tags:            fetchTags,
 		fetchSubmodules: fetchSubmodules,
 	}
-
 	opts = selectFilterTreeFetchOption(method, opts, filterTree)
 
 	return opts
@@ -318,7 +317,6 @@ func selectFilterTreeFetchOption(method CheckoutMethod, opts fetchOptions, filte
 		CheckoutForkCommitMethod:
 		{
 			opts.filterTree = true
-			opts.depth = 0
 			return opts
 		}
 	case CheckoutNoneMethod,
@@ -330,6 +328,25 @@ func selectFilterTreeFetchOption(method CheckoutMethod, opts fetchOptions, filte
 		}
 	default:
 		panic(fmt.Sprintf("implementation missing for enum value %T", method))
+	}
+}
+
+func idealDefaultCloneDepth(method CheckoutMethod) int {
+	switch method {
+	case CheckoutNoneMethod,
+		CheckoutPRMergeBranchMethod,
+		CheckoutPRManualMergeMethod,
+		CheckoutPRDiffFileMethod:
+		return 1
+	case CheckoutCommitMethod,
+		CheckoutTagMethod,
+		CheckoutBranchMethod,
+		CheckoutHeadBranchCommitMethod,
+		CheckoutForkCommitMethod:
+		fallthrough
+	default:
+		const defaultCloneDepth = 50
+		return defaultCloneDepth
 	}
 }
 

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -333,21 +333,12 @@ func selectFilterTreeFetchOption(method CheckoutMethod, opts fetchOptions, filte
 
 func idealDefaultCloneDepth(method CheckoutMethod) int {
 	const defaultCloneDepth = 50
+	const shallowCloneDepth = 1
 
-	switch method {
-	case CheckoutNoneMethod,
-		CheckoutPRMergeBranchMethod,
-		CheckoutPRManualMergeMethod,
-		CheckoutPRDiffFileMethod:
-		return 1
-	case CheckoutCommitMethod,
-		CheckoutTagMethod,
-		CheckoutBranchMethod,
-		CheckoutHeadBranchCommitMethod,
-		CheckoutForkCommitMethod:
-		fallthrough
-	default:
+	if method == CheckoutPRManualMergeMethod {
 		return defaultCloneDepth
+	} else {
+		return shallowCloneDepth
 	}
 }
 

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -332,6 +332,8 @@ func selectFilterTreeFetchOption(method CheckoutMethod, opts fetchOptions, filte
 }
 
 func idealDefaultCloneDepth(method CheckoutMethod) int {
+	const defaultCloneDepth = 50
+
 	switch method {
 	case CheckoutNoneMethod,
 		CheckoutPRMergeBranchMethod,
@@ -345,7 +347,6 @@ func idealDefaultCloneDepth(method CheckoutMethod) int {
 		CheckoutForkCommitMethod:
 		fallthrough
 	default:
-		const defaultCloneDepth = 50
 		return defaultCloneDepth
 	}
 }

--- a/gitclone/checkout_test.go
+++ b/gitclone/checkout_test.go
@@ -314,3 +314,54 @@ func Test_getBuildTriggerRef(t *testing.T) {
 		})
 	}
 }
+
+func Test_idealDefaultCloneDepth(t *testing.T) {
+	tests := []struct {
+		method CheckoutMethod
+		want   int
+	}{
+		{
+			method: CheckoutNoneMethod,
+			want:   1,
+		},
+		{
+			method: CheckoutPRMergeBranchMethod,
+			want:   1,
+		},
+		{
+			method: CheckoutPRManualMergeMethod,
+			want:   1,
+		},
+		{
+			method: CheckoutPRDiffFileMethod,
+			want:   1,
+		},
+		{
+			method: CheckoutCommitMethod,
+			want:   50,
+		},
+		{
+			method: CheckoutTagMethod,
+			want:   50,
+		},
+		{
+			method: CheckoutBranchMethod,
+			want:   50,
+		},
+		{
+			method: CheckoutHeadBranchCommitMethod,
+			want:   50,
+		},
+		{
+			method: CheckoutForkCommitMethod,
+			want:   50,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method.String(), func(t *testing.T) {
+			if got := idealDefaultCloneDepth(tt.method); got != tt.want {
+				t.Errorf("idealDefaultCloneDepth() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/gitclone/checkout_test.go
+++ b/gitclone/checkout_test.go
@@ -330,7 +330,7 @@ func Test_idealDefaultCloneDepth(t *testing.T) {
 		},
 		{
 			method: CheckoutPRManualMergeMethod,
-			want:   1,
+			want:   50,
 		},
 		{
 			method: CheckoutPRDiffFileMethod,
@@ -338,23 +338,23 @@ func Test_idealDefaultCloneDepth(t *testing.T) {
 		},
 		{
 			method: CheckoutCommitMethod,
-			want:   50,
+			want:   1,
 		},
 		{
 			method: CheckoutTagMethod,
-			want:   50,
+			want:   1,
 		},
 		{
 			method: CheckoutBranchMethod,
-			want:   50,
+			want:   1,
 		},
 		{
 			method: CheckoutHeadBranchCommitMethod,
-			want:   50,
+			want:   1,
 		},
 		{
 			method: CheckoutForkCommitMethod,
-			want:   50,
+			want:   1,
 		},
 	}
 	for _, tt := range tests {

--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -51,9 +51,9 @@ func checkoutState(gitCmd git.Git, cfg Config, patch patchSource) (strategy chec
 	checkoutStartTime := time.Now()
 	checkoutMethod, diffFile := selectCheckoutMethod(cfg, patch)
 
-	// If CloneDepth is -1, that means the user did not set a value for it,
+	// If CloneDepth is 0, that means the user did not set a value for it,
 	// so we will determine the correct value based on the checkout method.
-	if cfg.CloneDepth == -1 {
+	if cfg.CloneDepth == 0 {
 		cfg.CloneDepth = idealDefaultCloneDepth(checkoutMethod)
 	}
 

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -47,7 +47,7 @@ func Test_checkoutState(t *testing.T) {
 				FetchTags: true,
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 				`git "checkout" "76a934ae"`,
 			},
 		},
@@ -58,8 +58,8 @@ func Test_checkoutState(t *testing.T) {
 			},
 			mockRunner: givenMockRunnerSucceedsAfter(1),
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules"`,
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules"`,
 				`git "checkout" "76a934ae"`,
 			},
 		},
@@ -87,45 +87,45 @@ func Test_checkoutState(t *testing.T) {
 			},
 		},
 		{
-			name: "Checkout tag, branch specifed",
+			name: "Checkout tag, branch specified",
 			cfg: Config{
 				Tag: "gat",
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
 				`git "checkout" "gat"`,
 			},
 		},
 		{
-			name: "Checkout tag, branch specifed has same name as tag",
+			name: "Checkout tag, branch specified has same name as tag",
 			cfg: Config{
 				Tag: "gat",
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
 				`git "checkout" "gat"`,
 			},
 		},
 		{
-			name: "UNSUPPORTED Checkout commit, tag, branch specifed",
+			name: "UNSUPPORTED Checkout commit, tag, branch specified",
 			cfg: Config{
 				Commit: "76a934ae",
 				Tag:    "gat",
 				Branch: "hcnarb",
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 				`git "checkout" "76a934ae"`,
 			},
 		},
 		{
-			name: "UNSUPPORTED Checkout commit, tag specifed",
+			name: "UNSUPPORTED Checkout commit, tag specified",
 			cfg: Config{
 				Commit: "76a934ae",
 				Tag:    "gat",
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules"`,
 				`git "checkout" "76a934ae"`,
 			},
 		},
@@ -153,7 +153,7 @@ func Test_checkoutState(t *testing.T) {
 				ShouldMergePR: true,
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/pr_test:refs/remotes/pr_test"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/pr_test:refs/remotes/pr_test"`,
 				`git "checkout" "refs/remotes/pr_test"`,
 			},
 		},
@@ -169,7 +169,7 @@ func Test_checkoutState(t *testing.T) {
 				ShouldMergePR:         true,
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/7/merge:refs/remotes/pull/7/merge"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/7/merge:refs/remotes/pull/7/merge"`,
 				`git "checkout" "refs/remotes/pull/7/merge"`,
 			},
 		},
@@ -190,9 +190,9 @@ func Test_checkoutState(t *testing.T) {
 				GivenRunWithRetryFailsAfter(2).
 				GivenRunSucceeds(),
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "origin" "refs/heads/master"`,
-				`git "fetch" "--jobs=10" "--no-tags" "origin" "refs/heads/master"`,
-				`git "fetch" "--jobs=10" "--no-tags" "origin" "refs/heads/master"`,
+				`git "fetch" "--jobs=10" "--depth=50" "--no-tags" "origin" "refs/heads/master"`,
+				`git "fetch" "--jobs=10" "--depth=50" "--no-tags" "origin" "refs/heads/master"`,
+				`git "fetch" "--jobs=10" "--depth=50" "--no-tags" "origin" "refs/heads/master"`,
 				`git "fetch" "--jobs=10"`,
 				`git "branch" "-r"`,
 			},
@@ -265,15 +265,15 @@ func Test_checkoutState(t *testing.T) {
 				GivenRunWithRetrySucceeds().
 				GivenRunSucceeds(),
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 				`git "checkout" "master"`,
 				`git "apply" "--index" "diff_path"`,
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
 				`git "checkout" "master"`,
 				`git "merge" "origin/master"`,
 				`git "log" "-1" "--format=%H"`,
 				`git "remote" "add" "fork" "git@github.com:bitrise-io/other-repo.git"`,
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "fork" "refs/heads/test/commit-messages"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "fork" "refs/heads/test/commit-messages"`,
 				`git "merge" "fork/test/commit-messages"`,
 				`git "checkout" "--detach"`,
 			},
@@ -364,9 +364,9 @@ func Test_checkoutState(t *testing.T) {
 				GivenRunWithRetryFailsAfter(2).
 				GivenRunSucceeds(),
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/fake"`,
 				`git "fetch" "--jobs=10"`,
 				`git "branch" "-r"`,
 			},
@@ -421,7 +421,7 @@ func Test_checkoutState(t *testing.T) {
 				ShouldMergePR: true,
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/7/merge:refs/remotes/pull/7/merge"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/7/merge:refs/remotes/pull/7/merge"`,
 				`git "checkout" "refs/remotes/pull/7/merge"`,
 			},
 		},
@@ -446,7 +446,7 @@ func Test_checkoutState(t *testing.T) {
 				SparseDirectories: []string{"client/android"},
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 				`git "checkout" "76a934ae"`,
 			},
 		},

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -434,7 +434,7 @@ func Test_checkoutState(t *testing.T) {
 				SparseDirectories: []string{"client/android"},
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--filter=tree:0" "--no-tags" "--no-recurse-submodules"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--filter=tree:0" "--no-tags" "--no-recurse-submodules"`,
 				`git "checkout" "76a934a"`,
 			},
 		},
@@ -458,7 +458,7 @@ func Test_checkoutState(t *testing.T) {
 				SparseDirectories: []string{"client/android"},
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
 				`git "checkout" "hcnarb"`,
 				`git "merge" "origin/hcnarb"`,
 			},
@@ -471,7 +471,7 @@ func Test_checkoutState(t *testing.T) {
 				SparseDirectories: []string{"client/android"},
 			},
 			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/tags/gat:refs/tags/gat"`,
 				`git "checkout" "gat"`,
 			},
 		},

--- a/gitclone/steperror.go
+++ b/gitclone/steperror.go
@@ -16,7 +16,7 @@ func mapDetailedErrorRecommendation(tag, errMsg string) step.Recommendation {
 	switch tag {
 	case checkoutFailedTag:
 		matcher = newCheckoutFailedPatternErrorMatcher()
-	case updateSubmodelFailedTag:
+	case updateSubmoduleFailedTag:
 		matcher = newUpdateSubmoduleFailedErrorMatcher()
 	case fetchFailedTag:
 		matcher = newFetchFailedPatternErrorMatcher()

--- a/gitclone/steperror_test.go
+++ b/gitclone/steperror_test.go
@@ -82,7 +82,7 @@ fatal: Authentication failed for 'https://bitrise-io.git/'`)),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := mapDetailedErrorRecommendation(updateSubmodelFailedTag, tt.errMsg); !reflect.DeepEqual(got, tt.want) {
+			if got := mapDetailedErrorRecommendation(updateSubmoduleFailedTag, tt.errMsg); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("mapRecommendation() = %v, want %v", got, tt.want)
 			}
 		})

--- a/step.yml
+++ b/step.yml
@@ -131,7 +131,7 @@ inputs:
     value_options:
     - "yes"
     - "no"
-- clone_depth: -1
+- clone_depth:
   opts:
     category: Checkout options
     title: Limit fetching to the specified number of commits

--- a/step.yml
+++ b/step.yml
@@ -131,7 +131,7 @@ inputs:
     value_options:
     - "yes"
     - "no"
-- clone_depth:
+- clone_depth: -1
   opts:
     category: Checkout options
     title: Limit fetching to the specified number of commits


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Version update will be done when merging `next` into `master`.

### Context

To help speed up git clones, we want to provide more reasonable defaults for the clone depth. Most clones will now be shallow clones.

### Changes

- Clone depth is now determined based on the `CheckoutMethod` (shallow clone by default, but a depth of 50 for `CheckoutPRManualMergeMethod`). If the user specifies a value for the `clone_depth` input, we will use that value instead.
- Updated tests to match updates.
- Fixed a couple typos.