### PR TITLE
Replace incorrect spelling of COMMITER with COMMITTER

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,16 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 <details>
 <summary>Outputs</summary>
 
-| Environment Variable | Description |
-| --- | --- |
-| `GIT_CLONE_COMMIT_HASH` | SHA hash of the checked-out commit. |
-| `GIT_CLONE_COMMIT_MESSAGE_SUBJECT` | Commit message of the checked-out commit. |
-| `GIT_CLONE_COMMIT_MESSAGE_BODY` | Commit message body of the checked-out commit. |
-| `GIT_CLONE_COMMIT_COUNT` | Commit count after checkout.  Count will only work properly if no `--depth` option is set. If `--depth` is set then the history truncated to the specified number of commits. Count will **not** fail but will be the clone depth. |
-| `GIT_CLONE_COMMIT_AUTHOR_NAME` | Author of the checked-out commit. |
-| `GIT_CLONE_COMMIT_AUTHOR_EMAIL` | Email of the checked-out commit. |
-| `GIT_CLONE_COMMIT_COMMITER_NAME` | Committer name of the checked-out commit. |
-| `GIT_CLONE_COMMIT_COMMITER_EMAIL` | Email of the checked-out commit. |
+| Environment Variable               | Description                                                                                                                                                                                                                        |
+|------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `GIT_CLONE_COMMIT_HASH`            | SHA hash of the checked-out commit.                                                                                                                                                                                                |
+| `GIT_CLONE_COMMIT_MESSAGE_SUBJECT` | Commit message of the checked-out commit.                                                                                                                                                                                          |
+| `GIT_CLONE_COMMIT_MESSAGE_BODY`    | Commit message body of the checked-out commit.                                                                                                                                                                                     |
+| `GIT_CLONE_COMMIT_COUNT`           | Commit count after checkout.  Count will only work properly if no `--depth` option is set. If `--depth` is set then the history truncated to the specified number of commits. Count will **not** fail but will be the clone depth. |
+| `GIT_CLONE_COMMIT_AUTHOR_NAME`     | Author of the checked-out commit.                                                                                                                                                                                                  |
+| `GIT_CLONE_COMMIT_AUTHOR_EMAIL`    | Email of the checked-out commit.                                                                                                                                                                                                   |
+| `GIT_CLONE_COMMIT_COMMITTER_NAME`  | Committer name of the checked-out commit.                                                                                                                                                                                          |
+| `GIT_CLONE_COMMIT_COMMITTER_EMAIL` | Email of the checked-out commit.                                                                                                                                                                                                   |
 </details>
 
 ## 🙋 Contributing

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -517,8 +517,8 @@ workflows:
             check "GIT_CLONE_COMMIT_COUNT" "25"
             check "GIT_CLONE_COMMIT_AUTHOR_NAME" "Krisztian Dobmayer"
             check "GIT_CLONE_COMMIT_AUTHOR_EMAIL" "krisztian.dobmayer@bitrise.io"
-            check "GIT_CLONE_COMMIT_COMMITER_NAME" "Krisztian Dobmayer"
-            check "GIT_CLONE_COMMIT_COMMITER_EMAIL" "krisztian.dobmayer@bitrise.io"
+            check "GIT_CLONE_COMMIT_COMMITTER_NAME" "Krisztian Dobmayer"
+            check "GIT_CLONE_COMMIT_COMMITTER_EMAIL" "krisztian.dobmayer@bitrise.io"
 
   _check_too_long_message:
     steps:
@@ -548,8 +548,8 @@ workflows:
             echo "GIT_CLONE_COMMIT_COUNT: ${GIT_CLONE_COMMIT_COUNT}"
             echo "GIT_CLONE_COMMIT_AUTHOR_NAME: ${GIT_CLONE_COMMIT_AUTHOR_NAME}"
             echo "GIT_CLONE_COMMIT_AUTHOR_EMAIL: ${GIT_CLONE_COMMIT_AUTHOR_EMAIL}"
-            echo "GIT_CLONE_COMMIT_COMMITER_NAME: ${GIT_CLONE_COMMIT_COMMITER_NAME}"
-            echo "GIT_CLONE_COMMIT_COMMITER_EMAIL: ${GIT_CLONE_COMMIT_COMMITER_EMAIL}"
+            echo "GIT_CLONE_COMMIT_COMMITTER_NAME: ${GIT_CLONE_COMMIT_COMMITTER_NAME}"
+            echo "GIT_CLONE_COMMIT_COMMITTER_EMAIL: ${GIT_CLONE_COMMIT_COMMITTER_EMAIL}"
 
   _setup:
     steps:
@@ -579,8 +579,8 @@ workflows:
             envman unset --key GIT_CLONE_COMMIT_COUNT
             envman unset --key GIT_CLONE_COMMIT_AUTHOR_NAME
             envman unset --key GIT_CLONE_COMMIT_AUTHOR_EMAIL
-            envman unset --key GIT_CLONE_COMMIT_COMMITER_NAME
-            envman unset --key GIT_CLONE_COMMIT_COMMITER_EMAIL
+            envman unset --key GIT_CLONE_COMMIT_COMMITTER_NAME
+            envman unset --key GIT_CLONE_COMMIT_COMMITTER_EMAIL
 
   _run:
     steps:

--- a/gitclone/output.go
+++ b/gitclone/output.go
@@ -10,8 +10,8 @@ import (
 	"github.com/bitrise-io/go-utils/v2/command"
 )
 
-const outputCommitterName = "GIT_CLONE_COMMIT_COMMITER_NAME"
-const outputCommitterEmail = "GIT_CLONE_COMMIT_COMMITER_EMAIL"
+const outputCommitterName = "GIT_CLONE_COMMIT_COMMITTER_NAME"
+const outputCommitterEmail = "GIT_CLONE_COMMIT_COMMITTER_EMAIL"
 const outputCommitCount = "GIT_CLONE_COMMIT_COUNT"
 
 type gitOutput struct {

--- a/gitclone/output_test.go
+++ b/gitclone/output_test.go
@@ -49,11 +49,11 @@ func Test_gitOutputs(t *testing.T) {
 					gitCmd: gitCmd.Log("%b", "ref/tags/1.0.0"),
 				},
 				{
-					envKey: "GIT_CLONE_COMMIT_COMMITER_NAME",
+					envKey: "GIT_CLONE_COMMIT_COMMITTER_NAME",
 					gitCmd: gitCmd.Log("%cn", "ref/tags/1.0.0"),
 				},
 				{
-					envKey: "GIT_CLONE_COMMIT_COMMITER_EMAIL",
+					envKey: "GIT_CLONE_COMMIT_COMMITTER_EMAIL",
 					gitCmd: gitCmd.Log("%ce", "ref/tags/1.0.0"),
 				},
 				{

--- a/step.yml
+++ b/step.yml
@@ -233,11 +233,11 @@ outputs:
   opts:
     title: Commit author email
     description: Email of the checked-out commit.
-- GIT_CLONE_COMMIT_COMMITER_NAME:
+- GIT_CLONE_COMMIT_COMMITTER_NAME:
   opts:
     title: Committer name
     description: Committer name of the checked-out commit.
-- GIT_CLONE_COMMIT_COMMITER_EMAIL:
+- GIT_CLONE_COMMIT_COMMITTER_EMAIL:
   opts:
     title: Committer email
     description: Email of the checked-out commit.


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Version update will occur when `next` is merged in at the end.

### Context

I noticed that we had 2 environment variables with a typo in them. This fixes that.

### Changes

- Replace `GIT_CLONE_COMMIT_COMMITER_NAME` with `GIT_CLONE_COMMIT_COMMITTER_NAME`
- Replace `GIT_CLONE_COMMIT_COMMITER_EMAIL` with `GIT_CLONE_COMMIT_COMMITTER_EMAIL`