### PR TITLE
Use PR head ref in output export

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -602,6 +602,7 @@ workflows:
               envman add --key WORKDIR_ABSOLUTE --value $WD
             fi
     - path::./:
+        run_if: "true"
         inputs:
         - repository_url: $TEST_REPO_URL
         - clone_into_dir: $WORKDIR

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -291,6 +291,7 @@ workflows:
     - PULL_REQUEST_ID: 7
     - BITRISEIO_PULL_REQUEST_REPOSITORY_URL: git@github.com:bitrise-io/git-clone-test.git
     - BITRISEIO_PULL_REQUEST_MERGE_BRANCH: pull/7/merge
+    - BITRISEIO_PULL_REQUEST_HEAD_BRANCH: pull/7/head
     - BITRISEIO_GIT_BRANCH_DEST: master
     - COMMIT: 76a934ae80f12bb9b504bbc86f64a1d310e5db64
     - BRANCH: test/commit-messages
@@ -337,6 +338,7 @@ workflows:
     envs:
     - PULL_REQUEST_ID: 8
     - BITRISEIO_PULL_REQUEST_MERGE_BRANCH: pull/8/merge
+    - BITRISEIO_PULL_REQUEST_HEAD_BRANCH: pull/8/head
     - BITRISEIO_PULL_REQUEST_REPOSITORY_URL: $TEST_REPO_URL
     - BITRISEIO_GIT_BRANCH_DEST: unrelated-histories/master
     - COMMIT: 62af44590c7a2b937726f2c3024a88a129b330b5

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -222,7 +222,7 @@ func createCheckoutStrategy(checkoutMethod CheckoutMethod, cfg Config, patchFile
 		}
 	case CheckoutPRMergeBranchMethod:
 		{
-			params, err := NewPRMergeRefParams(cfg.PRDestBranch, cfg.PRMergeBranch)
+			params, err := NewPRMergeRefParams(cfg.PRDestBranch, cfg.PRMergeBranch, cfg.PRHeadBranch)
 			if err != nil {
 				return nil, err
 			}

--- a/gitclone/checkout.go
+++ b/gitclone/checkout.go
@@ -222,7 +222,7 @@ func createCheckoutStrategy(checkoutMethod CheckoutMethod, cfg Config, patchFile
 		}
 	case CheckoutPRMergeBranchMethod:
 		{
-			params, err := NewPRMergeRefParams(cfg.PRDestBranch, cfg.PRMergeBranch, cfg.PRHeadBranch)
+			params, err := NewPRMergeRefParams(cfg.PRMergeBranch, cfg.PRHeadBranch)
 			if err != nil {
 				return nil, err
 			}

--- a/gitclone/checkout_method_pr_auto_merge_branch.go
+++ b/gitclone/checkout_method_pr_auto_merge_branch.go
@@ -11,7 +11,6 @@ import (
 // When available, the merge ref is created by the git server and passed in the webhook.
 // Using a merge ref is preferred over a manual merge because we can shallow-fetch the merge ref only.
 type PRMergeRefParams struct {
-	DestinationBranch string
 	// MergeRef contains the changes pre-merged by the git provider (eg. pull/7/merge)
 	MergeRef string
 	// HeadRef is the head of the PR branch (eg. pull/7/head)
@@ -19,10 +18,7 @@ type PRMergeRefParams struct {
 }
 
 // NewPRMergeRefParams validates and returns a new PRMergeRefParams
-func NewPRMergeRefParams(destBranch, mergeRef, headRef string) (*PRMergeRefParams, error) {
-	if strings.TrimSpace(destBranch) == "" {
-		return nil, NewParameterValidationError("Can't checkout PR: no destination branch specified")
-	}
+func NewPRMergeRefParams(mergeRef, headRef string) (*PRMergeRefParams, error) {
 	if strings.TrimSpace(mergeRef) == "" {
 		return nil, NewParameterValidationError("Can't checkout PR: no merge ref specified")
 	}
@@ -31,9 +27,8 @@ func NewPRMergeRefParams(destBranch, mergeRef, headRef string) (*PRMergeRefParam
 	}
 
 	return &PRMergeRefParams{
-		DestinationBranch: destBranch,
-		MergeRef:          mergeRef,
-		HeadRef:           headRef,
+		MergeRef: mergeRef,
+		HeadRef:  headRef,
 	}, nil
 }
 

--- a/gitclone/checkout_method_pr_auto_merge_branch.go
+++ b/gitclone/checkout_method_pr_auto_merge_branch.go
@@ -14,20 +14,26 @@ type PRMergeRefParams struct {
 	DestinationBranch string
 	// MergeRef contains the changes pre-merged by the git provider (eg. pull/7/merge)
 	MergeRef string
+	// HeadRef is the head of the PR branch (eg. pull/7/head)
+	HeadRef string
 }
 
 // NewPRMergeRefParams validates and returns a new PRMergeRefParams
-func NewPRMergeRefParams(destBranch, mergeRef string) (*PRMergeRefParams, error) {
+func NewPRMergeRefParams(destBranch, mergeRef, headRef string) (*PRMergeRefParams, error) {
 	if strings.TrimSpace(destBranch) == "" {
 		return nil, NewParameterValidationError("Can't checkout PR: no destination branch specified")
 	}
 	if strings.TrimSpace(mergeRef) == "" {
 		return nil, NewParameterValidationError("Can't checkout PR: no merge ref specified")
 	}
+	if strings.TrimSpace(headRef) == "" {
+		return nil, NewParameterValidationError("Can't checkout PR: no head ref specified")
+	}
 
 	return &PRMergeRefParams{
 		DestinationBranch: destBranch,
 		MergeRef:          mergeRef,
+		HeadRef:           headRef,
 	}, nil
 }
 
@@ -37,7 +43,7 @@ type checkoutPRMergeRef struct {
 
 func (c checkoutPRMergeRef) do(gitCmd git.Git, fetchOpts fetchOptions, fallback fallbackRetry) error {
 	// https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
-	refSpec := fmt.Sprintf("%s:%s", c.remoteRef(), c.localRef())
+	refSpec := fmt.Sprintf("%s:%s", c.remoteMergeRef(), c.localMergeRef())
 
 	// $ git fetch origin refs/remotes/pull/7/merge:refs/pull/7/merge
 	err := fetch(gitCmd, originRemoteName, refSpec, fetchOpts)
@@ -45,8 +51,15 @@ func (c checkoutPRMergeRef) do(gitCmd git.Git, fetchOpts fetchOptions, fallback 
 		return err
 	}
 
+	// Also fetch the PR head ref because the step exports outputs based on the PR head commit (see output.go)
+	// $ git fetch origin refs/remotes/pull/7/head:refs/pull/7/head
+	err = c.fetchPRHeadRef(gitCmd, fetchOpts)
+	if err != nil {
+		return err
+	}
+
 	// $ git checkout refs/remotes/pull/7/merge
-	err = checkoutWithCustomRetry(gitCmd, c.localRef(), nil)
+	err = checkoutWithCustomRetry(gitCmd, c.localMergeRef(), nil)
 	if err != nil {
 		return err
 	}
@@ -55,13 +68,26 @@ func (c checkoutPRMergeRef) do(gitCmd git.Git, fetchOpts fetchOptions, fallback 
 }
 
 func (c checkoutPRMergeRef) getBuildTriggerRef() string {
-	return c.localRef()
+	return c.localHeadRef()
 }
 
-func (c checkoutPRMergeRef) localRef() string {
+func (c checkoutPRMergeRef) localMergeRef() string {
 	return fmt.Sprintf("refs/remotes/%s", c.params.MergeRef)
 }
 
-func (c checkoutPRMergeRef) remoteRef() string {
+func (c checkoutPRMergeRef) remoteMergeRef() string {
 	return fmt.Sprintf("refs/%s", c.params.MergeRef)
+}
+
+func (c checkoutPRMergeRef) localHeadRef() string {
+	return fmt.Sprintf("refs/remotes/%s", c.params.HeadRef)
+}
+
+func (c checkoutPRMergeRef) remoteHeadRef() string {
+	return fmt.Sprintf("refs/%s", c.params.HeadRef)
+}
+
+func (c checkoutPRMergeRef) fetchPRHeadRef(gitCmd git.Git, fetchOpts fetchOptions) error {
+	refSpec := fmt.Sprintf("%s:%s", c.remoteHeadRef(), c.localHeadRef())
+	return fetch(gitCmd, originRemoteName, refSpec, fetchOpts)
 }

--- a/gitclone/checkout_test.go
+++ b/gitclone/checkout_test.go
@@ -301,9 +301,10 @@ func Test_getBuildTriggerRef(t *testing.T) {
 				params: PRMergeRefParams{
 					DestinationBranch: "dest",
 					MergeRef:          "pull/2/merge",
+					HeadRef:           "pull/2/head",
 				},
 			},
-			wantRef: "refs/remotes/pull/2/merge",
+			wantRef: "refs/remotes/pull/2/head",
 		},
 	}
 	for _, tt := range tests {

--- a/gitclone/checkout_test.go
+++ b/gitclone/checkout_test.go
@@ -299,9 +299,8 @@ func Test_getBuildTriggerRef(t *testing.T) {
 		{
 			strategy: checkoutPRMergeRef{
 				params: PRMergeRefParams{
-					DestinationBranch: "dest",
-					MergeRef:          "pull/2/merge",
-					HeadRef:           "pull/2/head",
+					MergeRef: "pull/2/merge",
+					HeadRef:  "pull/2/head",
 				},
 			},
 			wantRef: "refs/remotes/pull/2/head",

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -142,6 +142,7 @@ func Test_checkoutState(t *testing.T) {
 			},
 			wantCmds: []string{
 				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/5/merge:refs/remotes/pull/5/merge"`,
+				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/5/head:refs/remotes/pull/5/head"`,
 				`git "checkout" "refs/remotes/pull/5/merge"`,
 			},
 		},
@@ -152,10 +153,7 @@ func Test_checkoutState(t *testing.T) {
 				PRMergeBranch: "pr_test",
 				ShouldMergePR: true,
 			},
-			wantCmds: []string{
-				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/pr_test:refs/remotes/pr_test"`,
-				`git "checkout" "refs/remotes/pr_test"`,
-			},
+			wantErrType: ParameterValidationError{},
 		},
 		{
 			name: "PR - fork - merge ref: private fork",
@@ -165,11 +163,13 @@ func Test_checkoutState(t *testing.T) {
 				Branch:                "test/commit-messages",
 				PRDestBranch:          "master",
 				PRMergeBranch:         "pull/7/merge",
+				PRHeadBranch:          "pull/7/head",
 				Commit:                "76a934ae",
 				ShouldMergePR:         true,
 			},
 			wantCmds: []string{
 				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/7/merge:refs/remotes/pull/7/merge"`,
+				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/7/head:refs/remotes/pull/7/head"`,
 				`git "checkout" "refs/remotes/pull/7/merge"`,
 			},
 		},
@@ -417,11 +417,13 @@ func Test_checkoutState(t *testing.T) {
 			cfg: Config{
 				Branch:        "test/commit-messages",
 				PRMergeBranch: "pull/7/merge",
+				PRHeadBranch:  "pull/7/head",
 				PRDestBranch:  "master",
 				ShouldMergePR: true,
 			},
 			wantCmds: []string{
 				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/7/merge:refs/remotes/pull/7/merge"`,
+				`git "fetch" "--jobs=10" "--no-tags" "--no-recurse-submodules" "origin" "refs/pull/7/head:refs/remotes/pull/7/head"`,
 				`git "checkout" "refs/remotes/pull/7/merge"`,
 			},
 		},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

With #186, the step checks out the PR merge ref and uses that state to export outputs, such as the commit hash and commit message. This might be confusing for users (previous discussions: #89, #165), it makes more sense to use the PR head ref for output exports.

### Changes

- Fetch the PR head ref in addition to the PR merge ref. We do it with the same fetch params, so this should be a shallow fetch in most cases.
- Use the local head ref for exporting outputs
- Remove an unused parameter from the checkout method

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
