### PR TITLE
Disable git GC before fetch

### DIFF
--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -153,11 +153,11 @@ func Execute(cfg Config) error {
 	// Disable automatic GC as it may be triggered by other git commands (making run times nondeterministic).
 	// And we run in ephemeral VMs anyway, so GC isn't really needed.
 	// https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-gc.html
-	err = gitCmd.Config("gc.auto", "0").Run()
+	out, err := gitCmd.Config("gc.auto", "0").RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		return newStepError(
 			"disable_gc",
-			fmt.Errorf("failed to disable GC: %v", err),
+			fmt.Errorf("failed to disable GC: %v, output:\n%s", err, out),
 			"Failed to disable git garbage collection",
 		)
 	}

--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -150,6 +150,18 @@ func Execute(cfg Config) error {
 		)
 	}
 
+	// Disable automatic GC as it may be triggered by other git commands (making run times nondeterministic).
+	// And we run in ephemeral VMs anyway, so GC isn't really needed.
+	// https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-gc.html
+	err = gitCmd.Config("gc.auto", "0").Run()
+	if err != nil {
+		return newStepError(
+			"disable_gc",
+			fmt.Errorf("failed to disable GC: %v", err),
+			"Failed to disable git garbage collection",
+		)
+	}
+
 	originPresent, err := isOriginPresent(gitCmd, cfg.CloneIntoDir, cfg.RepositoryURL)
 	if err != nil {
 		return newStepError(

--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -150,18 +150,6 @@ func Execute(cfg Config) error {
 		)
 	}
 
-	// Disable automatic GC as it may be triggered by other git commands (making run times nondeterministic).
-	// And we run in ephemeral VMs anyway, so GC isn't really needed.
-	// https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-gc.html
-	out, err := gitCmd.Config("gc.auto", "0").RunAndReturnTrimmedCombinedOutput()
-	if err != nil {
-		return newStepError(
-			"disable_gc",
-			fmt.Errorf("failed to disable GC: %v, output:\n%s", err, out),
-			"Failed to disable git garbage collection",
-		)
-	}
-
 	originPresent, err := isOriginPresent(gitCmd, cfg.CloneIntoDir, cfg.RepositoryURL)
 	if err != nil {
 		return newStepError(
@@ -195,6 +183,18 @@ func Execute(cfg Config) error {
 				"Adding remote repository failed",
 			)
 		}
+	}
+
+	// Disable automatic GC as it may be triggered by other git commands (making run times nondeterministic).
+	// And we run in ephemeral VMs anyway, so GC isn't really needed.
+	// https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-gc.html
+	out, err := gitCmd.Config("gc.auto", "0").RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		return newStepError(
+			"disable_gc",
+			fmt.Errorf("failed to disable GC: %v, output:\n%s", err, out),
+			"Failed to disable git garbage collection",
+		)
 	}
 
 	if err := setupSparseCheckout(gitCmd, cfg.SparseDirectories); err != nil {

--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -188,11 +188,11 @@ func Execute(cfg Config) error {
 	// Disable automatic GC as it may be triggered by other git commands (making run times nondeterministic).
 	// And we run in ephemeral VMs anyway, so GC isn't really needed.
 	// https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-gc.html
-	out, err := gitCmd.Config("gc.auto", "0").RunAndReturnTrimmedCombinedOutput()
+	err = runner.Run(gitCmd.Config("gc.auto", "0"))
 	if err != nil {
 		return newStepError(
 			"disable_gc",
-			fmt.Errorf("failed to disable GC: %v, output:\n%s", err, out),
+			fmt.Errorf("failed to disable GC: %v", err),
 			"Failed to disable git garbage collection",
 		)
 	}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

It's probably a good idea to disable [git GC](https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-gc.html) to make step run times more deterministic. See the investigation details section for numbers.

### Changes

Run `git config gc.auto 0` before the fetch commands.

### Investigation details

I created a Go benchmark for measuring the difference. This test case fetches the https://github.com/androidx/androidx repo main branch, which has quite a long history. It's not a super scientific test as it includes a lot of network calls, but at least it shows that this change doesn't slow us down:

```
❯ go test -bench=BenchmarkBranchShallowFetch -run=^# -benchtime=3x
goos: darwin
goarch: arm64
pkg: github.com/bitrise-steplib/steps-git-clone/gitclone
BenchmarkBranchShallowFetch/jobs=10,disableGC=false-10                 3        6757783875 ns/op
BenchmarkBranchShallowFetch/jobs=10,disableGC=true-10                  3        6427483806 ns/op
```

The reason I'm not including the benchmark in this PR is that it required uncommenting a few parts of the step code to make it work.

### Decisions

<!-- Please list decisions that were made for this change. -->
