### PR TITLE
feat: GCI-17 Remove explicit LFS dependency on git clone step

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -37,11 +37,6 @@ is_requires_admin_user: false
 is_always_run: false
 is_skippable: false
 run_if: .IsCI
-deps:
-  brew:
-  - name: git-lfs
-  apt_get:
-  - name: git-lfs
 toolkit:
   go:
     package_name: github.com/bitrise-steplib/steps-git-clone


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Making sure the step binary works in container environments, i.e. it doesn't depend on too many external binaries. `git` itself is an obvious binary that we don't want to get rid of now (although there is `libgit2`), but `git-lfs` is more like an optional dependency of the step that only a small percentage of step users actively trigger.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
