### PR TITLE
Clean dirty state before checkout

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -18,10 +18,27 @@ app:
 workflows:
   test_dirty_state_before_checkout:
     envs:
-    - BRANCH: conflict-test/a
-    - BRANCH_DEST: conflict-test/b
+    - BITRISEIO_PULL_REQUEST_MERGE_BRANCH: pull/5/merge
+    - BITRISEIO_PULL_REQUEST_HEAD_BRANCH: pull/5/head
+    - BITRISEIO_GIT_BRANCH_DEST: master
+    - COMMIT: 4301a9b8499ed3e87778dd053c55fd698d0a3b7e
+    - MERGE_PR: "yes"
+    - UPDATE_SUBMODULES: "no"
     before_run:
     - _setup
+    steps:
+    - script:
+        title: Make a mess
+        is_skippable: true
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -ex
+            cd $WORKDIR
+            git clone $TEST_REPO_URL .
+            git checkout conflict-test/b
+            git merge origin/conflict-test/a || true
+            git status
     after_run:
     - _run
     - _check_outputs
@@ -601,14 +618,6 @@ workflows:
             envman unset --key GIT_CLONE_COMMIT_AUTHOR_EMAIL
             envman unset --key GIT_CLONE_COMMIT_COMMITTER_NAME
             envman unset --key GIT_CLONE_COMMIT_COMMITTER_EMAIL
-
-  _run:
-    steps:
-    - activate-ssh-key:
-        run_if: |-
-          {{ getenv "GIT_CLONE_SSH_PRIVATE_KEY" | ne "" }}
-        inputs:
-        - ssh_rsa_private_key: $GIT_CLONE_SSH_PRIVATE_KEY
     - script:
         inputs:
         - title: Create temporary dir
@@ -621,6 +630,14 @@ workflows:
               envman add --key WORKDIR --value $WD
               envman add --key WORKDIR_ABSOLUTE --value $WD
             fi
+
+  _run:
+    steps:
+    - activate-ssh-key:
+        run_if: |-
+          {{ getenv "GIT_CLONE_SSH_PRIVATE_KEY" | ne "" }}
+        inputs:
+        - ssh_rsa_private_key: $GIT_CLONE_SSH_PRIVATE_KEY
     - path::./:
         run_if: "true"
         inputs:
@@ -635,7 +652,7 @@ workflows:
         - merge_pr: $MERGE_PR
         - clone_depth: $CLONE_DEPTH
         - sparse_directories: $SPARSE_DIRECTORIES
-        - pull_request_repository_url: PR_REPO_URL
+        - pull_request_repository_url: $PR_REPO_URL
 
   _teardown:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -5,6 +5,7 @@ app:
   envs:
   - ORIGINAL_WORKDIR: $BITRISE_SOURCE_DIR
   - TEST_REPO_URL: https://github.com/bitrise-io/git-clone-test.git
+  - PR_REPO_URL: https://github.com/bitrise-io/git-clone-test.git
   - FETCH_TAGS: "no"
   - UPDATE_SUBMODULES: "yes"
   - MERGE_PR: "yes"
@@ -634,6 +635,7 @@ workflows:
         - merge_pr: $MERGE_PR
         - clone_depth: $CLONE_DEPTH
         - sparse_directories: $SPARSE_DIRECTORIES
+        - pull_request_repository_url: PR_REPO_URL
 
   _teardown:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -15,34 +15,6 @@ app:
   - GIT_HTTP_PASSWORD_FOR_TEST: $GIT_HTTP_PASSWORD_FOR_TEST
 
 workflows:
-  test_dirty_state_before_checkout:
-    envs:
-    - BITRISEIO_PULL_REQUEST_MERGE_BRANCH: pull/5/merge
-    - BITRISEIO_PULL_REQUEST_HEAD_BRANCH: pull/5/head
-    - BITRISEIO_GIT_BRANCH_DEST: master
-    - COMMIT: 4301a9b8499ed3e87778dd053c55fd698d0a3b7e
-    - MERGE_PR: "yes"
-    - UPDATE_SUBMODULES: "no"
-    before_run:
-    - _setup
-    steps:
-    - script:
-        title: Make a mess
-        is_skippable: true
-        inputs:
-        - content: |-
-            #!/bin/env bash
-            set -ex
-            cd $WORKDIR
-            git clone $TEST_REPO_URL .
-            git checkout conflict-test/b
-            git merge origin/conflict-test/a || true
-            git status
-    after_run:
-    - _run
-    - _check_outputs
-    - _teardown
-
   test_generate_changelog_by_commit:
     envs:
     - COMMIT: a409478
@@ -497,6 +469,34 @@ workflows:
     - GIT_HTTP_PASSWORD: $GIT_HTTP_PASSWORD_FOR_TEST
     before_run:
     - _setup
+    after_run:
+    - _run
+    - _check_outputs
+    - _teardown
+  
+  test_dirty_state_before_checkout:
+    envs:
+    - BITRISEIO_PULL_REQUEST_MERGE_BRANCH: pull/5/merge
+    - BITRISEIO_PULL_REQUEST_HEAD_BRANCH: pull/5/head
+    - BITRISEIO_GIT_BRANCH_DEST: master
+    - COMMIT: 4301a9b8499ed3e87778dd053c55fd698d0a3b7e
+    - MERGE_PR: "yes"
+    - UPDATE_SUBMODULES: "no"
+    before_run:
+    - _setup
+    steps:
+    - script:
+        title: Make a mess
+        is_skippable: true
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -ex
+            cd $WORKDIR
+            git clone $TEST_REPO_URL .
+            git checkout conflict-test/b
+            git merge origin/conflict-test/a || true
+            git status
     after_run:
     - _run
     - _check_outputs

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -5,7 +5,6 @@ app:
   envs:
   - ORIGINAL_WORKDIR: $BITRISE_SOURCE_DIR
   - TEST_REPO_URL: https://github.com/bitrise-io/git-clone-test.git
-  - PR_REPO_URL: https://github.com/bitrise-io/git-clone-test.git
   - FETCH_TAGS: "no"
   - UPDATE_SUBMODULES: "yes"
   - MERGE_PR: "yes"
@@ -645,14 +644,12 @@ workflows:
         - clone_into_dir: $WORKDIR
         - commit: $COMMIT
         - branch: $BRANCH
-        - branch_dest: $BRANCH_DEST
         - tag: $TAG
         - fetch_tags: $FETCH_TAGS
         - update_submodules: $UPDATE_SUBMODULES
         - merge_pr: $MERGE_PR
         - clone_depth: $CLONE_DEPTH
         - sparse_directories: $SPARSE_DIRECTORIES
-        - pull_request_repository_url: $PR_REPO_URL
 
   _teardown:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -473,7 +473,7 @@ workflows:
     - _run
     - _check_outputs
     - _teardown
-  
+
   test_dirty_state_before_checkout:
     envs:
     - BITRISEIO_PULL_REQUEST_MERGE_BRANCH: pull/5/merge

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -15,6 +15,17 @@ app:
   - GIT_HTTP_PASSWORD_FOR_TEST: $GIT_HTTP_PASSWORD_FOR_TEST
 
 workflows:
+  test_dirty_state_before_checkout:
+    envs:
+    - BRANCH: conflict-test/a
+    - BRANCH_DEST: conflict-test/b
+    before_run:
+    - _setup
+    after_run:
+    - _run
+    - _check_outputs
+    - _teardown
+
   test_generate_changelog_by_commit:
     envs:
     - COMMIT: a409478
@@ -616,6 +627,7 @@ workflows:
         - clone_into_dir: $WORKDIR
         - commit: $COMMIT
         - branch: $BRANCH
+        - branch_dest: $BRANCH_DEST
         - tag: $TAG
         - fetch_tags: $FETCH_TAGS
         - update_submodules: $UPDATE_SUBMODULES

--- a/gitclone/git.go
+++ b/gitclone/git.go
@@ -150,3 +150,13 @@ func handleCheckoutError(callback getAvailableBranches, tag string, err error, s
 		shortMsg,
 	)
 }
+
+func isWorkingTreeClean(gitCmd git.Git) (bool, error) {
+	// Despite the flag name, `--porcelain` is the plumbing format to use in scripts:
+	// https://git-scm.com/docs/git-status#Documentation/git-status.txt---porcelainltversiongt
+	out, err := gitCmd.Status("--porcelain").RunAndReturnTrimmedOutput()
+	if err != nil {
+		return false, fmt.Errorf("git status check: %s", err)
+	}
+	return strings.TrimSpace(out) == "", nil
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

When running on self-hosted agents, a previous merge conflict could leave the working tree in a dirty state. The step needs to do a reset before the checkout.

### Changes

- Detect if the working tree is dirty
- Do a `reset` and `clean` if so
- Handle errors gracefully and continue execution. It's possible that either a `reset` or a `clean` is enough, depending on the working tree state.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
