### PR TITLE
Force-checkout remote branch to fix unrelated histories

### DIFF
--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -114,9 +114,9 @@ func forceCheckoutRemoteBranch(gitCmd git.Git, remote string, branchRef string, 
 	if err != nil {
 		return handleCheckoutError(
 			listBranches(gitCmd),
-			fetchFailedTag,
+			checkoutFailedTag,
 			err,
-			"Fetching repository has failed",
+			"Checkout has failed",
 			branch,
 		)
 	}

--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -112,7 +112,7 @@ func forceCheckoutRemoteBranch(gitCmd git.Git, remote string, branchRef string, 
 	// so the next run would see unrelated histories after shallow-fetching another single commit.
 	out, err := runner.RunForOutput(command.New("git", "checkout", "-B", branch, remoteBranch))
 	if err != nil {
-		fmt.Printf(out)
+		fmt.Println(out)
 		return fmt.Errorf("checkout remote-tracking branch %s: %w", remoteBranch, err)
 	}
 

--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -110,10 +110,15 @@ func forceCheckoutRemoteBranch(gitCmd git.Git, remote string, branchRef string, 
 	// -B: create the branch if it doesn't exist, reset if it does
 	// The latter is important in persistent environments because shallow-fetching only fetches 1 commit,
 	// so the next run would see unrelated histories after shallow-fetching another single commit.
-	out, err := runner.RunForOutput(command.New("git", "checkout", "-B", branch, remoteBranch))
+	err := runner.Run(gitCmd.Checkout("-B", branch, remoteBranch))
 	if err != nil {
-		fmt.Println(out)
-		return fmt.Errorf("checkout remote-tracking branch %s: %w", remoteBranch, err)
+		return handleCheckoutError(
+			listBranches(gitCmd),
+			fetchFailedTag,
+			err,
+			"Fetching repository has failed",
+			branch,
+		)
 	}
 
 	return nil

--- a/gitclone/checkout_helper.go
+++ b/gitclone/checkout_helper.go
@@ -99,31 +99,21 @@ func checkoutWithCustomRetry(gitCmd git.Git, arg string, retry fallbackRetry) er
 	return nil
 }
 
-func fetchInitialBranch(gitCmd git.Git, remote string, branchRef string, fetchTraits fetchOptions) error {
+func forceCheckoutRemoteBranch(gitCmd git.Git, remote string, branchRef string, fetchTraits fetchOptions) error {
 	branch := strings.TrimPrefix(branchRef, refsHeadsPrefix)
 	if err := fetch(gitCmd, remote, branchRef, fetchTraits); err != nil {
-		wErr := fmt.Errorf("failed to fetch branch (%s): %w", branchRef, err)
+		wErr := fmt.Errorf("fetch branch %s: %w", branchRef, err)
 		return fmt.Errorf("%v: %w", wErr, errors.New("please make sure the branch still exists"))
 	}
-
-	if err := checkoutWithCustomRetry(gitCmd, branch, nil); err != nil {
-		return handleCheckoutError(
-			listBranches(gitCmd),
-			checkoutFailedTag,
-			err,
-			"Checkout has failed",
-			branch,
-		)
-	}
-
-	// Update branch: 'git fetch' followed by a 'git merge' is the same as 'git pull'.
+	
 	remoteBranch := fmt.Sprintf("%s/%s", remote, branch)
-	if err := runner.Run(gitCmd.Merge(remoteBranch)); err != nil {
-		return newStepError(
-			"update_branch_failed",
-			fmt.Errorf("updating branch (%s) failed: %w", branch, err),
-			"Updating branch failed",
-		)
+	// -B: create the branch if it doesn't exist, reset if it does
+	// The latter is important in persistent environments because shallow-fetching only fetches 1 commit,
+	// so the next run would see unrelated histories after shallow-fetching another single commit.
+	out, err := runner.RunForOutput(command.New("git", "checkout", "-B", branch, remoteBranch))
+	if err != nil {
+		fmt.Printf(out)
+		return fmt.Errorf("checkout remote-tracking branch %s: %w", remoteBranch, err)
 	}
 
 	return nil

--- a/gitclone/checkout_method_pr_manual.go
+++ b/gitclone/checkout_method_pr_manual.go
@@ -61,7 +61,7 @@ type checkoutPRManualMerge struct {
 func (c checkoutPRManualMerge) do(gitCmd git.Git, fetchOptions fetchOptions, fallback fallbackRetry) error {
 	// Fetch and checkout destinations branch
 	destBranchRef := refsHeadsPrefix + c.params.DestinationBranch
-	if err := fetchInitialBranch(gitCmd, originRemoteName, destBranchRef, fetchOptions); err != nil {
+	if err := forceCheckoutRemoteBranch(gitCmd, originRemoteName, destBranchRef, fetchOptions); err != nil {
 		return fmt.Errorf("failed to fetch base branch: %w", err)
 	}
 

--- a/gitclone/checkout_method_simple.go
+++ b/gitclone/checkout_method_simple.go
@@ -91,7 +91,7 @@ type checkoutBranch struct {
 }
 
 func (c checkoutBranch) do(gitCmd git.Git, fetchOptions fetchOptions, _ fallbackRetry) error {
-	if err := fetchInitialBranch(gitCmd, originRemoteName, c.localRef(), fetchOptions); err != nil {
+	if err := forceCheckoutRemoteBranch(gitCmd, originRemoteName, c.localRef(), fetchOptions); err != nil {
 		return err
 	}
 

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -76,8 +76,7 @@ func Test_checkoutState(t *testing.T) {
 			},
 			wantCmds: []string{
 				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
-				`git "checkout" "hcnarb"`,
-				`git "merge" "origin/hcnarb"`,
+				`git "checkout" "-B" "hcnarb" "origin/hcnarb"`,
 			},
 		},
 		{
@@ -204,7 +203,7 @@ func Test_checkoutState(t *testing.T) {
 				`git "fetch" "--jobs=10"`,
 				`git "branch" "-r"`,
 			},
-			wantErr: fmt.Errorf("failed to fetch base branch: failed to fetch branch (refs/heads/master): dummy_cmd_error: please make sure the branch still exists"),
+			wantErr: fmt.Errorf("failed to fetch base branch: fetch branch refs/heads/master: dummy_cmd_error: please make sure the branch still exists"),
 		},
 		{
 			name: "PR - fork - no merge ref - diff file available",
@@ -245,8 +244,7 @@ func Test_checkoutState(t *testing.T) {
 				`git "checkout" "master"`,
 				`git "apply" "--index" "diff_path"`,
 				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
-				`git "checkout" "master"`,
-				`git "merge" "origin/master"`,
+				`git "checkout" "-B" "master" "origin/master"`,
 				`git "log" "-1" "--format=%H"`,
 				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/test/commit-messages"`,
 				`git "merge" "76a934ae"`,
@@ -273,8 +271,7 @@ func Test_checkoutState(t *testing.T) {
 				`git "checkout" "master"`,
 				`git "apply" "--index" "diff_path"`,
 				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/master"`,
-				`git "checkout" "master"`,
-				`git "merge" "origin/master"`,
+				`git "checkout" "-B" "master" "origin/master"`,
 				`git "log" "-1" "--format=%H"`,
 				`git "remote" "add" "fork" "git@github.com:bitrise-io/other-repo.git"`,
 				`git "fetch" "--jobs=10" "--depth=1" "--no-tags" "--no-recurse-submodules" "fork" "refs/heads/test/commit-messages"`,
@@ -375,7 +372,7 @@ func Test_checkoutState(t *testing.T) {
 			},
 			wantErr: newStepErrorWithBranchRecommendations(
 				fetchFailedTag,
-				fmt.Errorf("failed to fetch branch (refs/heads/fake): %w: please make sure the branch still exists", errors.New(rawCmdError)),
+				fmt.Errorf("fetch branch refs/heads/fake: %w: please make sure the branch still exists", errors.New(rawCmdError)),
 				"Fetching repository has failed",
 				"fake",
 				[]string{"master"},
@@ -466,8 +463,7 @@ func Test_checkoutState(t *testing.T) {
 			},
 			wantCmds: []string{
 				`git "fetch" "--jobs=10" "--depth=1" "--filter=tree:0" "--no-tags" "--no-recurse-submodules" "origin" "refs/heads/hcnarb"`,
-				`git "checkout" "hcnarb"`,
-				`git "merge" "origin/hcnarb"`,
+				`git "checkout" "-B" "hcnarb" "origin/hcnarb"`,
 			},
 		},
 		{

--- a/gitclone/output_test.go
+++ b/gitclone/output_test.go
@@ -13,7 +13,7 @@ import (
 func Test_gitOutputs(t *testing.T) {
 	gitCmd, err := git.New(t.TempDir())
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	type args struct {
 		gitRef string

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bitrise-io/envman v0.0.0-20210517135508-b2b4fe89eac5
 	github.com/bitrise-io/go-steputils v1.0.5
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.15
-	github.com/bitrise-io/go-utils v1.0.14-0.20241213163208-7104b0101841
+	github.com/bitrise-io/go-utils v1.0.14
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.15
 	github.com/bitrise-steplib/steps-authenticate-host-with-netrc v0.0.0-20230711084209-91fcd09b2017
 	github.com/hashicorp/go-retryablehttp v0.7.7

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bitrise-io/envman v0.0.0-20210517135508-b2b4fe89eac5
 	github.com/bitrise-io/go-steputils v1.0.5
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.15
-	github.com/bitrise-io/go-utils v1.0.13
+	github.com/bitrise-io/go-utils v1.0.14-0.20241213163208-7104b0101841
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.15
 	github.com/bitrise-steplib/steps-authenticate-host-with-netrc v0.0.0-20230711084209-91fcd09b2017
 	github.com/hashicorp/go-retryablehttp v0.7.7

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/bitrise-io/go-utils v0.0.0-20210507100250-37de47dfa6ce/go.mod h1:15EZ
 github.com/bitrise-io/go-utils v0.0.0-20210514083430-4d1fb0330dfe/go.mod h1:DRx7oFuAqk0dbKpAKCqWl0TgrowfJUb/MqYPRscxJOQ=
 github.com/bitrise-io/go-utils v0.0.0-20210517140706-aa64fd88ca49/go.mod h1:DRx7oFuAqk0dbKpAKCqWl0TgrowfJUb/MqYPRscxJOQ=
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils v1.0.13 h1:1QENhTS/JlKH9F7+/nB+TtbTcor6jGrE6cQ4CJWfp5U=
-github.com/bitrise-io/go-utils v1.0.13/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
+github.com/bitrise-io/go-utils v1.0.14-0.20241213163208-7104b0101841 h1:UbDuwrjY1ONky1Kk5i6vZhpgymoHZdn8bygsJ2XYEO4=
+github.com/bitrise-io/go-utils v1.0.14-0.20241213163208-7104b0101841/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.15 h1:ERQb+OOa+eKMWb+HByyPd5ugz6TeaJPnQ3xHgyaR7hA=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.15/go.mod h1:Laih4ji980SQkRgdnMCH0g4u2GZI/5nnbqmYT9UfKFQ=
 github.com/bitrise-io/go-xcode v0.0.0-20210517092111-792daa927657/go.mod h1:OexOTlMlXuf88bsFsaw5KxmIYrYDsHkTh01vbhGNpus=
@@ -42,6 +42,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+CFIY7dBJI=
 github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
@@ -50,12 +51,10 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
-github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
-github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -69,6 +68,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -123,8 +124,6 @@ golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
-golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,12 @@ github.com/bitrise-io/go-utils v0.0.0-20210507100250-37de47dfa6ce/go.mod h1:15EZ
 github.com/bitrise-io/go-utils v0.0.0-20210514083430-4d1fb0330dfe/go.mod h1:DRx7oFuAqk0dbKpAKCqWl0TgrowfJUb/MqYPRscxJOQ=
 github.com/bitrise-io/go-utils v0.0.0-20210517140706-aa64fd88ca49/go.mod h1:DRx7oFuAqk0dbKpAKCqWl0TgrowfJUb/MqYPRscxJOQ=
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
+github.com/bitrise-io/go-utils v1.0.13 h1:1QENhTS/JlKH9F7+/nB+TtbTcor6jGrE6cQ4CJWfp5U=
+github.com/bitrise-io/go-utils v1.0.13/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils v1.0.14-0.20241213163208-7104b0101841 h1:UbDuwrjY1ONky1Kk5i6vZhpgymoHZdn8bygsJ2XYEO4=
 github.com/bitrise-io/go-utils v1.0.14-0.20241213163208-7104b0101841/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
+github.com/bitrise-io/go-utils v1.0.14 h1:hrBriQh47qvy4p3pLkc7gEw9qCWEJYESTJ19ggHRpYs=
+github.com/bitrise-io/go-utils v1.0.14/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.15 h1:ERQb+OOa+eKMWb+HByyPd5ugz6TeaJPnQ3xHgyaR7hA=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.15/go.mod h1:Laih4ji980SQkRgdnMCH0g4u2GZI/5nnbqmYT9UfKFQ=
 github.com/bitrise-io/go-xcode v0.0.0-20210517092111-792daa927657/go.mod h1:OexOTlMlXuf88bsFsaw5KxmIYrYDsHkTh01vbhGNpus=

--- a/vendor/github.com/bitrise-io/go-utils/command/git/commands.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/git/commands.go
@@ -48,9 +48,10 @@ func (g *Git) Fetch(opts ...string) *command.Model {
 }
 
 // Checkout switches branches or restore working tree files.
-// Arg can be a commit hash, a branch or a tag.
-func (g *Git) Checkout(arg string) *command.Model {
-	return g.command("checkout", arg)
+func (g *Git) Checkout(args ...string) *command.Model {
+	a := []string{"checkout"}
+	a = append(a, args...)
+	return g.command(a...)
 }
 
 // Merge joins two or more development histories together.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/bitrise-io/go-steputils/step
 ## explicit; go 1.17
 github.com/bitrise-io/go-steputils/v2/export
 github.com/bitrise-io/go-steputils/v2/stepconf
-# github.com/bitrise-io/go-utils v1.0.14-0.20241213163208-7104b0101841
+# github.com/bitrise-io/go-utils v1.0.14
 ## explicit; go 1.13
 github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/bitrise-io/go-steputils/step
 ## explicit; go 1.17
 github.com/bitrise-io/go-steputils/v2/export
 github.com/bitrise-io/go-steputils/v2/stepconf
-# github.com/bitrise-io/go-utils v1.0.13
+# github.com/bitrise-io/go-utils v1.0.14-0.20241213163208-7104b0101841
 ## explicit; go 1.13
 github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Git clones can fail in persistent environments (bare-metal runners) when the build is triggered by a push event. Imagine this sequence:
1. Build 1 runs with the default step settings. It fetches `origin/main` (because it's not a PR build) with `--depth=1` (default step setting).
2. New commits are pushed to `origin/main`
3. Build 2 runs: it fetches `origin/main` again with `--depth=1`, but when it tries to checkout and merge the local branch, it fails with the `refusing to merge unrelated histories` error.

An actual step log:

```
$ git "init"
Reinitialized existing Git repository in /home/bitrise-admin/ca71a338453a42a3/git/.git/
$ git "config" "gc.auto" "0"
$ git "fetch" "--jobs=10" "--depth=1" "--no-tags" "origin" "refs/heads/master"
From github.com:bitrise-io/ubuntu-android
 * branch            master     -> FETCH_HEAD
 + d0413b1...db22ecf master     -> origin/master  (forced update)
$ git "checkout" "master"
Switched to branch 'master'
Your branch and 'origin/master' have diverged,
and have 1 and 1 different commits each, respectively.
  (use "git pull" to merge the remote branch into yours)
$ git "merge" "origin/master"
fatal: refusing to merge unrelated histories
Checkout strategy used: gitclone.checkoutBranch
Failed to execute Step:
  updating branch (master) failed:
    fatal: refusing to merge unrelated histories
```

### Changes

Branch checkout was implemented using a `fetch` + `checkout` + `merge remote local` sequence. This doesn't work in persistent envs because there is a leftover local branch from the previous run with a single commit (because of shallow fetching). The new remote-tracking branch also has a single commit, and there is no common ancestor of these two commits, so the merge command fails.

This PR changes the implementation of our branch checkout so that any previous local branch state is overwritten, sort of like a `git pull --force`.

The end result remains the same:
- The branch is checked out
- It is not behind origin
- If the local branch already exists, it's overwritten
- [new] If the local and remote branches diverged, the remote state wins

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
