### PR TITLE
Add performance monitoring support

### DIFF
--- a/gitclone/command_runner.go
+++ b/gitclone/command_runner.go
@@ -19,16 +19,23 @@ type CommandRunner interface {
 	RunForOutput(c *command.Model) (string, error)
 	Run(c *command.Model) error
 	RunWithRetry(getCommmand func() *command.Model) error
+	SetPerformanceMonitoring(enable bool)
+	PausePerformanceMonitoring()
+	ResumePerformanceMonitoring()
 }
 
 // DefaultRunner ...
 type DefaultRunner struct {
+	performanceMonitoringEnabled             bool
+	performanceMonitoringTemporarilyDisabled bool
 }
 
 // RunForOutput ...
-func (r DefaultRunner) RunForOutput(c *command.Model) (string, error) {
+func (r *DefaultRunner) RunForOutput(c *command.Model) (string, error) {
 	fmt.Println()
 	log.Infof("$ %s &> out", c.PrintableCommandArgs())
+
+	r.setupPerformanceMonitoring(c)
 
 	out, err := c.RunAndReturnTrimmedCombinedOutput()
 	if err != nil && errorutil.IsExitStatusError(err) {
@@ -39,10 +46,12 @@ func (r DefaultRunner) RunForOutput(c *command.Model) (string, error) {
 }
 
 // Run ...
-func (r DefaultRunner) Run(c *command.Model) error {
+func (r *DefaultRunner) Run(c *command.Model) error {
 	fmt.Println()
 	log.Infof("$ %s", c.PrintableCommandArgs())
 	var buffer bytes.Buffer
+
+	r.setupPerformanceMonitoring(c)
 
 	err := c.SetStdout(os.Stdout).SetStderr(io.MultiWriter(os.Stderr, &buffer)).Run()
 	if err != nil {
@@ -60,7 +69,7 @@ func (r DefaultRunner) Run(c *command.Model) error {
 }
 
 // RunWithRetry ...
-func (r DefaultRunner) RunWithRetry(getCommand func() *command.Model) error {
+func (r *DefaultRunner) RunWithRetry(getCommand func() *command.Model) error {
 	return retry.Times(2).Wait(5).Try(func(attempt uint) error {
 		if attempt > 0 {
 			log.Warnf("Retrying...")
@@ -74,4 +83,27 @@ func (r DefaultRunner) RunWithRetry(getCommand func() *command.Model) error {
 
 		return err
 	})
+}
+
+func (r *DefaultRunner) SetPerformanceMonitoring(enable bool) {
+	r.performanceMonitoringEnabled = enable
+}
+
+func (r *DefaultRunner) PausePerformanceMonitoring() {
+	r.performanceMonitoringTemporarilyDisabled = true
+}
+
+func (r *DefaultRunner) ResumePerformanceMonitoring() {
+	r.performanceMonitoringTemporarilyDisabled = false
+}
+
+func (r *DefaultRunner) setupPerformanceMonitoring(c *command.Model) {
+	if r.performanceMonitoringTemporarilyDisabled {
+		c.AppendEnvs("GIT_TRACE2_PERF=0")
+		return
+	}
+
+	if r.performanceMonitoringEnabled {
+		c.AppendEnvs("GIT_TRACE2_PERF=1")
+	}
 }

--- a/gitclone/command_runner_test.go
+++ b/gitclone/command_runner_test.go
@@ -1,0 +1,88 @@
+package gitclone
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerformanceMonitoring(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialState  *bool
+		shouldDisable bool
+		want          *string
+	}{
+		{
+			name:         "Normal case",
+			initialState: nil,
+			want:         nil,
+		},
+		{
+			name:         "Enable performance monitoring",
+			initialState: pointer(true),
+			want:         pointer("1"),
+		},
+		{
+			name:         "Disable performance monitoring",
+			initialState: pointer(false),
+		},
+		{
+			name:          "Temporarily disable performance monitoring",
+			initialState:  pointer(true),
+			shouldDisable: true,
+			want:          pointer("0"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := DefaultRunner{}
+
+			if tt.initialState != nil {
+				r.SetPerformanceMonitoring(*tt.initialState)
+			}
+
+			if tt.shouldDisable {
+				r.PausePerformanceMonitoring()
+			}
+
+			cmd := command.New("echo", "hello")
+			err := r.Run(cmd)
+			require.NoError(t, err)
+
+			value, ok := getEnv(cmd.GetCmd(), "GIT_TRACE2_PERF")
+
+			if tt.want == nil {
+				require.Equal(t, "", value)
+				require.False(t, ok)
+				return
+			}
+
+			if tt.shouldDisable {
+				require.Equal(t, "0", value)
+				require.True(t, ok)
+				return
+			}
+
+			require.Equal(t, *tt.want, value)
+			require.True(t, ok)
+		})
+	}
+}
+
+func pointer[T any](d T) *T {
+	return &d
+}
+
+func getEnv(cmd *exec.Cmd, key string) (string, bool) {
+	for _, env := range cmd.Env {
+		if strings.HasPrefix(env, key) {
+			return strings.TrimPrefix(env, key+"="), true
+		}
+	}
+	return "", false
+}

--- a/gitclone/git.go
+++ b/gitclone/git.go
@@ -16,7 +16,7 @@ const (
 	jobsFlag          = "--jobs=10"
 )
 
-var runner CommandRunner = DefaultRunner{}
+var runner CommandRunner = &DefaultRunner{}
 
 func isOriginPresent(gitCmd git.Git, dir, repoURL string) (bool, error) {
 	absDir, err := pathutil.AbsPath(dir)

--- a/gitclone/gitclone.go
+++ b/gitclone/gitclone.go
@@ -51,7 +51,9 @@ type GitCloner struct {
 	mergeRefChecker bitriseapi.MergeRefChecker
 }
 
-func NewGitCloner(logger log.Logger, tracker tracker.StepTracker, cmdFactory command.Factory, patchSource bitriseapi.PatchSource, mergeRefChecker bitriseapi.MergeRefChecker) GitCloner {
+func NewGitCloner(logger log.Logger, tracker tracker.StepTracker, cmdFactory command.Factory, patchSource bitriseapi.PatchSource, mergeRefChecker bitriseapi.MergeRefChecker, performanceMonitoring bool) GitCloner {
+	runner.SetPerformanceMonitoring(performanceMonitoring)
+
 	return GitCloner{
 		logger:          logger,
 		tracker:         tracker,

--- a/gitclone/gitclone_test.go
+++ b/gitclone/gitclone_test.go
@@ -495,7 +495,7 @@ func Test_checkoutState(t *testing.T) {
 			envRepo := env.NewRepository()
 			logger := log.NewLogger()
 			tracker := tracker.NewStepTracker(envRepo, logger)
-			cloner := NewGitCloner(log.NewLogger(), tracker, command.NewFactory(envRepo), tt.patchSource, tt.mergeRefChecker)
+			cloner := NewGitCloner(log.NewLogger(), tracker, command.NewFactory(envRepo), tt.patchSource, tt.mergeRefChecker, false)
 			_, _, actualErr := cloner.checkoutState(git.Git{}, tt.cfg)
 
 			// Then

--- a/gitclone/mock_command_runner_test.go
+++ b/gitclone/mock_command_runner_test.go
@@ -89,6 +89,15 @@ func (m *MockRunner) GivenRunWithRetryFailsAfter(times int) *MockRunner {
 	return m
 }
 
+func (m *MockRunner) SetPerformanceMonitoring(enable bool) {
+}
+
+func (m *MockRunner) PausePerformanceMonitoring() {
+}
+
+func (m *MockRunner) ResumePerformanceMonitoring() {
+}
+
 func (m *MockRunner) rememberCommand(args mock.Arguments) {
 	var cmdModel *command.Model
 	switch res := args[0].(type) {

--- a/gitclone/output.go
+++ b/gitclone/output.go
@@ -112,6 +112,9 @@ func (e *OutputExporter) gitOutputs(gitRef string, isPR bool) []gitOutput {
 }
 
 func (e *OutputExporter) printLogAndExportEnv(command *v1command.Model, env string, maxEnvLength int) error {
+	runner.PausePerformanceMonitoring()
+	defer runner.ResumePerformanceMonitoring()
+
 	l, err := runner.RunForOutput(command)
 	if err != nil {
 		return fmt.Errorf("command failed: %s", err)

--- a/step.yml
+++ b/step.yml
@@ -227,6 +227,16 @@ inputs:
     - "No"
     - "Yes"
 
+- performance_monitoring: "no"
+  opts:
+    category: Debug
+    title: Performance monitoring
+    summary: Enable performance monitoring.
+    description: Prints extra performance related information for every git operation.
+    value_options:
+      - "no"
+      - "yes"
+
 - build_url: $BITRISE_BUILD_URL
   opts:
     category: Debug

--- a/step.yml
+++ b/step.yml
@@ -234,8 +234,8 @@ inputs:
     summary: Enable performance monitoring.
     description: Prints extra performance related information for every git operation.
     value_options:
-      - "no"
-      - "yes"
+    - "no"
+    - "yes"
 
 - build_url: $BITRISE_BUILD_URL
   opts:

--- a/step/step.go
+++ b/step/step.go
@@ -106,7 +106,7 @@ func (g GitCloneStep) Run(cfg Config) (gitclone.CheckoutStateResult, error) {
 	gitCloneCfg := convertConfig(cfg)
 	patchSource := bitriseapi.NewPatchSource(cfg.BuildURL, cfg.BuildAPIToken)
 	mergeRefChecker := bitriseapi.NewMergeRefChecker(cfg.BuildURL, cfg.BuildAPIToken, retry.NewHTTPClient(), g.logger, g.tracker)
-	cloner := gitclone.NewGitCloner(g.logger, g.tracker, g.cmdFactory, patchSource, mergeRefChecker)
+	cloner := gitclone.NewGitCloner(g.logger, g.tracker, g.cmdFactory, patchSource, mergeRefChecker, cfg.PerformanceMonitoring)
 	return cloner.CheckoutState(gitCloneCfg)
 }
 

--- a/step/step.go
+++ b/step/step.go
@@ -39,9 +39,10 @@ type Input struct {
 	PRUnverifiedMergeBranch string `env:"pull_request_unverified_merge_branch"`
 	PRHeadBranch            string `env:"pull_request_head_branch"`
 
-	ResetRepository bool   `env:"reset_repository,opt[Yes,No]"`
-	BuildURL        string `env:"build_url"`
-	BuildAPIToken   string `env:"build_api_token"`
+	ResetRepository       bool   `env:"reset_repository,opt[Yes,No]"`
+	PerformanceMonitoring bool   `env:"performance_monitoring,opt[yes,no]"`
+	BuildURL              string `env:"build_url"`
+	BuildAPIToken         string `env:"build_api_token"`
 }
 
 // Config is the git clone step configuration


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

There is a need to add low level git performance logging to the logs. It can be already done by setting the `GIT_TRACE2_PERF` env var but this also messes up the step outputs because when the query the commit hash, author and other exported fields we receive the performance logs as part of the output. We need to explicitly disable logging for those commands. 