### PR TITLE
Fix for very small maximum env sizes (smaller than '...')

### DIFF
--- a/gitclone/output.go
+++ b/gitclone/output.go
@@ -111,6 +111,22 @@ func (e *OutputExporter) gitOutputs(gitRef string, isPR bool) []gitOutput {
 	return outputs
 }
 
+func trimEnv(logger log.Logger, envKey string, envValue string, maxEnvLength int) string {
+	if len(envValue) <= maxEnvLength {
+		return envValue
+	}
+
+	if maxEnvLength <= len(trimEnding) {
+		logger.Warnf("Maximum env length size (%d) is too small to fit anything, setting %s to '%s'", maxEnvLength, envKey, trimEnding)
+		return trimEnding
+	}
+
+	tv := envValue[:maxEnvLength-len(trimEnding)] + trimEnding
+	logger.Printf("Value %s is bigger than maximum env variable size, trimming", envKey)
+
+	return tv
+}
+
 func (e *OutputExporter) printLogAndExportEnv(command *v1command.Model, env string, maxEnvLength int) error {
 	runner.PausePerformanceMonitoring()
 	defer runner.ResumePerformanceMonitoring()
@@ -120,10 +136,8 @@ func (e *OutputExporter) printLogAndExportEnv(command *v1command.Model, env stri
 		return fmt.Errorf("command failed: %s", err)
 	}
 
-	if (env == "GIT_CLONE_COMMIT_MESSAGE_SUBJECT" || env == "GIT_CLONE_COMMIT_MESSAGE_BODY") && len(l) > maxEnvLength {
-		tv := l[:maxEnvLength-len(trimEnding)] + trimEnding
-		e.logger.Printf("Value %s  is bigger than maximum env variable size, trimming", env)
-		l = tv
+	if env == "GIT_CLONE_COMMIT_MESSAGE_SUBJECT" || env == "GIT_CLONE_COMMIT_MESSAGE_BODY" {
+		l = trimEnv(e.logger, env, l, maxEnvLength)
 	}
 
 	e.logger.Printf("=> %s\n   value: %s", env, l)

--- a/gitclone/output_test.go
+++ b/gitclone/output_test.go
@@ -107,3 +107,43 @@ func Test_gitOutputs(t *testing.T) {
 		})
 	}
 }
+
+func Test_trimEnv(t *testing.T) {
+	logger := log.NewLogger()
+	tests := []struct {
+		name         string
+		envKey       string
+		envValue     string
+		maxEnvLength int
+		want         string
+	}{
+		{
+			name:         "long value, trimmed",
+			envKey:       "TEST_ENV",
+			envValue:     "Short value",
+			maxEnvLength: 20,
+			want:         "Short value",
+		},
+		{
+			name:         "long value, trimmed",
+			envKey:       "TEST_ENV",
+			envValue:     "Somewhat long value that exceeds the limit",
+			maxEnvLength: 6,
+			want:         "Som...",
+		},
+		{
+			name:         "max env length smaller than trimEnding length",
+			envKey:       "TEST_ENV",
+			envValue:     "Somewhat long value that exceeds the limit",
+			maxEnvLength: 0,
+			want:         "...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trimEnv(logger, tt.envKey, tt.envValue, tt.maxEnvLength); got != tt.want {
+				t.Errorf("trimEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

When maximum env length size is very small (<= 3), set the value of `...` to the env.
<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
